### PR TITLE
Add python style request logging

### DIFF
--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/plugin/Plugin.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/plugin/Plugin.java
@@ -130,7 +130,8 @@ public class Plugin {
 						webServerConfig.getWebserverPort(),
 						webServerConfig.getWebserverMaxConnections(),
 						webServerConfig.getWebserverBindAdress(),
-						requestHandler
+						requestHandler,
+                                                false
 					);
 					webServer.start();
 				}

--- a/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/webserver/HttpConnection.java
+++ b/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/webserver/HttpConnection.java
@@ -34,6 +34,9 @@ import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
 
 import de.bluecolored.bluemap.core.logger.Logger;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class HttpConnection implements Runnable {
 
@@ -66,6 +69,19 @@ public class HttpConnection implements Runnable {
 				HttpRequest request = acceptRequest();
 				HttpResponse response = handler.handle(request);
 				sendResponse(response);
+                                
+                                DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+                                Date date = new Date();
+                                Logger.global.logInfo(
+                                        connection.getInetAddress().toString() +
+                                        " [ " +
+                                        dateFormat.format(date) +
+                                        " ] \"" +
+                                        request.getMethod() +
+                                        " " + request.getPath() +
+                                        " " + request.getVersion() +
+                                        "\" " +
+                                        response.getStatusCode().toString());
 			} catch (InvalidRequestException e){
 				try {
 					sendResponse(new HttpResponse(HttpStatusCode.BAD_REQUEST));

--- a/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/webserver/HttpConnection.java
+++ b/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/webserver/HttpConnection.java
@@ -46,11 +46,14 @@ public class HttpConnection implements Runnable {
 	private Socket connection;
 	private InputStream in;
 	private OutputStream out;
+        
+        private final boolean verbose;
 	
-	public HttpConnection(ServerSocket server, Socket connection, HttpRequestHandler handler, int timeout, TimeUnit timeoutUnit) throws IOException {
+	public HttpConnection(ServerSocket server, Socket connection, HttpRequestHandler handler, int timeout, TimeUnit timeoutUnit, boolean verbose) throws IOException {
 		this.server = server;
 		this.connection = connection;
 		this.handler = handler;
+                this.verbose = verbose;
 		
 		if (isClosed()){
 			throw new IOException("Socket already closed!");
@@ -69,19 +72,20 @@ public class HttpConnection implements Runnable {
 				HttpRequest request = acceptRequest();
 				HttpResponse response = handler.handle(request);
 				sendResponse(response);
-                                
-                                DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-                                Date date = new Date();
-                                Logger.global.logInfo(
-                                        connection.getInetAddress().toString() +
-                                        " [ " +
-                                        dateFormat.format(date) +
-                                        " ] \"" +
-                                        request.getMethod() +
-                                        " " + request.getPath() +
-                                        " " + request.getVersion() +
-                                        "\" " +
-                                        response.getStatusCode().toString());
+                                if (verbose) {
+                                    DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+                                    Date date = new Date();
+                                    Logger.global.logInfo(
+                                            connection.getInetAddress().toString() +
+                                            " [ " +
+                                            dateFormat.format(date) +
+                                            " ] \"" +
+                                            request.getMethod() +
+                                            " " + request.getPath() +
+                                            " " + request.getVersion() +
+                                            "\" " +
+                                            response.getStatusCode().toString());
+                                }
 			} catch (InvalidRequestException e){
 				try {
 					sendResponse(new HttpResponse(HttpStatusCode.BAD_REQUEST));

--- a/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/webserver/HttpConnection.java
+++ b/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/webserver/HttpConnection.java
@@ -72,20 +72,9 @@ public class HttpConnection implements Runnable {
 				HttpRequest request = acceptRequest();
 				HttpResponse response = handler.handle(request);
 				sendResponse(response);
-                                if (verbose) {
-                                    DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-                                    Date date = new Date();
-                                    Logger.global.logInfo(
-                                            connection.getInetAddress().toString() +
-                                            " [ " +
-                                            dateFormat.format(date) +
-                                            " ] \"" +
-                                            request.getMethod() +
-                                            " " + request.getPath() +
-                                            " " + request.getVersion() +
-                                            "\" " +
-                                            response.getStatusCode().toString());
-                                }
+				if (verbose) {
+					log(request, response);
+				}
 			} catch (InvalidRequestException e){
 				try {
 					sendResponse(new HttpResponse(HttpStatusCode.BAD_REQUEST));
@@ -109,6 +98,21 @@ public class HttpConnection implements Runnable {
 			Logger.global.logError("Error while closing HttpConnection!", e);
 		}
 	}
+        
+        private void log(HttpRequest request, HttpResponse response) {
+		DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+		Date date = new Date();
+		Logger.global.logInfo(
+			connection.getInetAddress().toString()
+			+ " [ "
+			+ dateFormat.format(date)
+			+ " ] \""
+			+ request.getMethod()
+			+ " " + request.getPath()
+			+ " " + request.getVersion()
+			+ "\" "
+			+ response.getStatusCode().toString());
+        }
 	
 	private void sendResponse(HttpResponse response) throws IOException {
 		response.write(out);

--- a/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/webserver/WebServer.java
+++ b/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/webserver/WebServer.java
@@ -41,6 +41,7 @@ public class WebServer extends Thread {
 	private final int port;
 	private final int maxConnections;
 	private final InetAddress bindAdress;
+        private final boolean verbose;
 
 	private HttpRequestHandler handler;
 	
@@ -48,10 +49,11 @@ public class WebServer extends Thread {
 	
 	private ServerSocket server;
 
-	public WebServer(int port, int maxConnections, InetAddress bindAdress, HttpRequestHandler handler) {
+	public WebServer(int port, int maxConnections, InetAddress bindAdress, HttpRequestHandler handler, boolean verbose) {
 		this.port = port;
 		this.maxConnections = maxConnections;
 		this.bindAdress = bindAdress;
+                this.verbose = verbose;
 		
 		this.handler = handler;
 		
@@ -81,7 +83,7 @@ public class WebServer extends Thread {
 				Socket connection = server.accept();
 				
 				try {
-					connectionThreads.execute(new HttpConnection(server, connection, handler, 10, TimeUnit.SECONDS));
+					connectionThreads.execute(new HttpConnection(server, connection, handler, 10, TimeUnit.SECONDS, verbose));
 				} catch (RejectedExecutionException e){
 					connection.close();
 					Logger.global.logWarning("Dropped an incoming HttpConnection! (Too many connections?)");

--- a/implementations/cli/src/main/java/de/bluecolored/bluemap/cli/BlueMapCLI.java
+++ b/implementations/cli/src/main/java/de/bluecolored/bluemap/cli/BlueMapCLI.java
@@ -227,7 +227,7 @@ public class BlueMapCLI {
 		Logger.global.logInfo("Render finished!");
 	}
 	
-	public void startWebserver(BlueMapService blueMap) throws IOException {
+	public void startWebserver(BlueMapService blueMap, boolean verbose) throws IOException {
 		Logger.global.logInfo("Starting webserver ...");
 		
 		WebServerConfig config = blueMap.getWebServerConfig();
@@ -237,7 +237,8 @@ public class BlueMapCLI {
 			config.getWebserverPort(),
 			config.getWebserverMaxConnections(),
 			config.getWebserverBindAdress(),
-			requestHandler
+			requestHandler,
+                        verbose
 		);
 		webServer.start();
 	}
@@ -283,7 +284,7 @@ public class BlueMapCLI {
 			if (cmd.hasOption("w")) {
 				noActions = false;
 				
-				cli.startWebserver(blueMap);
+				cli.startWebserver(blueMap, cmd.hasOption("b"));
 				Thread.sleep(1000); //wait a second to let the webserver start, looks nicer in the log if anything comes after that
 			}
 			
@@ -374,6 +375,7 @@ public class BlueMapCLI {
 			);
 		
 		options.addOption("w", "webserver", false, "Starts the web-server, configured in the 'webserver.conf' file");
+                options.addOption("b", "verbose", false, "Causes the web-server to log requests to the console");
 
 		options.addOption("g", "generate-webapp", false, "Generates the files for the web-app to the folder, configured in the 'render.conf' file (this is done automatically when rendering if the 'index.html' file in the webroot can't be found)");
 		options.addOption("s", "generate-websettings", false, "Generates the settings for the web-app, using the settings from the 'render.conf' file (this is done automatically when rendering)");


### PR DESCRIPTION
Addresses part of #98 by adding Python style request logging to the server.

BlueMap makes many requests so the log is often very long - this may not be an optimal way to see connections to the server.

This is an initial pull request to get feedback - I am open to changing what is logged or provide an option because I think this is a good idea but currently this basically spams the terminal window any time someone connects.

![logging](https://user-images.githubusercontent.com/1860011/94847924-7b3bb400-03e0-11eb-840c-51ca44ab4285.PNG)
