### PR TITLE
Get world by string resource location

### DIFF
--- a/implementations/fabric-1.15.2/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.15.2/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -149,6 +149,11 @@ public class FabricMod implements ModInitializer, ServerInterface {
         if (world instanceof Path)
             return getWorld((Path) world);
 
+        if (world instanceof String) {
+            Identifier identifier = Identifier.tryParse((String) world);
+            if (identifier != null) world = identifier;
+        }
+
         if (world instanceof Identifier) {
             DimensionType dimensionType = DimensionType.byId((Identifier) world);
             if (dimensionType != null) world = dimensionType;

--- a/implementations/fabric-1.16.1/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.16.1/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -43,6 +43,8 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
@@ -149,6 +151,11 @@ public class FabricMod implements ModInitializer, ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            Identifier identifier = Identifier.tryParse((String) world);
+            if (identifier != null) world = serverInstance.getWorld(RegistryKey.of(Registry.DIMENSION, identifier));
+        }
 
         if (world instanceof RegistryKey) {
             try {

--- a/implementations/fabric-1.16.2/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.16.2/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -43,6 +43,8 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
@@ -149,6 +151,11 @@ public class FabricMod implements ModInitializer, ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            Identifier identifier = Identifier.tryParse((String) world);
+            if (identifier != null) world = serverInstance.getWorld(RegistryKey.of(Registry.DIMENSION, identifier));
+        }
 
         if (world instanceof RegistryKey) {
             try {

--- a/implementations/fabric-1.17/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.17/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -43,6 +43,8 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
@@ -149,6 +151,11 @@ public class FabricMod implements ModInitializer, ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            Identifier identifier = Identifier.tryParse((String) world);
+            if (identifier != null) world = serverInstance.getWorld(RegistryKey.of(Registry.WORLD_KEY, identifier));
+        }
 
         if (world instanceof RegistryKey) {
             try {

--- a/implementations/fabric-1.18/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.18/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -43,6 +43,8 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
@@ -149,6 +151,11 @@ public class FabricMod implements ModInitializer, ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            Identifier identifier = Identifier.tryParse((String) world);
+            if (identifier != null) world = serverInstance.getWorld(RegistryKey.of(Registry.WORLD_KEY, identifier));
+        }
 
         if (world instanceof RegistryKey) {
             try {

--- a/implementations/fabric-1.19/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.19/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -43,6 +43,8 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
@@ -149,6 +151,11 @@ public class FabricMod implements ModInitializer, ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            Identifier identifier = Identifier.tryParse((String) world);
+            if (identifier != null) world = serverInstance.getWorld(RegistryKey.of(Registry.WORLD_KEY, identifier));
+        }
 
         if (world instanceof RegistryKey) {
             try {

--- a/implementations/forge-1.14.4/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.14.4/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -162,6 +162,13 @@ public class ForgeMod implements ServerInterface {
         if (world instanceof Path)
             return getWorld((Path) world);
 
+        if (world instanceof String) {
+            ResourceLocation resourceLocation = ResourceLocation.tryCreate((String) world);
+            DimensionType dimensionType = null;
+            if (resourceLocation != null) dimensionType = DimensionType.byName(resourceLocation);
+            if (dimensionType != null) world = serverInstance.getWorld(dimensionType);
+        }
+
         if (world instanceof ResourceLocation) {
             DimensionType dimensionType = DimensionType.byName((ResourceLocation) world);
             if (dimensionType != null) world = dimensionType;

--- a/implementations/forge-1.15.2/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.15.2/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -162,6 +162,13 @@ public class ForgeMod implements ServerInterface {
         if (world instanceof Path)
             return getWorld((Path) world);
 
+        if (world instanceof String) {
+            ResourceLocation resourceLocation = ResourceLocation.tryCreate((String) world);
+            DimensionType dimensionType = null;
+            if (resourceLocation != null) dimensionType = DimensionType.byName(resourceLocation);
+            if (dimensionType != null) world = serverInstance.getWorld(dimensionType);
+        }
+
         if (world instanceof ResourceLocation) {
             DimensionType dimensionType = DimensionType.byName((ResourceLocation) world);
             if (dimensionType != null) world = dimensionType;

--- a/implementations/forge-1.16.2/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.16.2/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -39,6 +39,8 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.RegistryKey;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent.ServerTickEvent;
@@ -162,6 +164,11 @@ public class ForgeMod implements ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            ResourceLocation resourceLocation = ResourceLocation.tryCreate((String) world);
+            if (resourceLocation != null) world = serverInstance.getWorld(RegistryKey.func_240903_a_(Registry.field_239699_ae_, resourceLocation));
+        }
 
         if (world instanceof RegistryKey) {
             try {

--- a/implementations/forge-1.17.1/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.17.1/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -35,7 +35,9 @@ import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.MinecraftVersion;
 import de.bluecolored.bluemap.core.logger.Logger;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -161,6 +163,11 @@ public class ForgeMod implements ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            ResourceLocation resourceLocation = ResourceLocation.tryParse((String) world);
+            if (resourceLocation != null) world = serverInstance.getLevel(ResourceKey.create(Registry.DIMENSION_REGISTRY, resourceLocation));
+        }
 
         if (world instanceof ResourceKey) {
             try {

--- a/implementations/forge-1.18.1/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.18.1/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -35,7 +35,9 @@ import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.MinecraftVersion;
 import de.bluecolored.bluemap.core.logger.Logger;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -161,6 +163,11 @@ public class ForgeMod implements ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            ResourceLocation resourceLocation = ResourceLocation.tryParse((String) world);
+            if (resourceLocation != null) world = serverInstance.getLevel(ResourceKey.create(Registry.DIMENSION_REGISTRY, resourceLocation));
+        }
 
         if (world instanceof ResourceKey) {
             try {

--- a/implementations/forge-1.19.1/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.19.1/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -35,7 +35,9 @@ import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.MinecraftVersion;
 import de.bluecolored.bluemap.core.logger.Logger;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -161,6 +163,11 @@ public class ForgeMod implements ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            ResourceLocation resourceLocation = ResourceLocation.tryParse((String) world);
+            if (resourceLocation != null) world = serverInstance.getLevel(ResourceKey.create(Registry.DIMENSION_REGISTRY, resourceLocation));
+        }
 
         if (world instanceof ResourceKey) {
             try {

--- a/implementations/forge-1.19/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.19/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -35,7 +35,9 @@ import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.MinecraftVersion;
 import de.bluecolored.bluemap.core.logger.Logger;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -161,6 +163,11 @@ public class ForgeMod implements ServerInterface {
     public Optional<ServerWorld> getWorld(Object world) {
         if (world instanceof Path)
             return getWorld((Path) world);
+
+        if (world instanceof String) {
+            ResourceLocation resourceLocation = ResourceLocation.tryParse((String) world);
+            if (resourceLocation != null) world = serverInstance.getLevel(ResourceKey.create(Registry.DIMENSION_REGISTRY, resourceLocation));
+        }
 
         if (world instanceof ResourceKey) {
             try {

--- a/implementations/spigot/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlugin.java
+++ b/implementations/spigot/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlugin.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.MinecraftVersion;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -197,6 +198,11 @@ public class BukkitPlugin extends JavaPlugin implements ServerInterface, Listene
 
         if (world instanceof String) {
             var serverWorld = Bukkit.getWorld((String) world);
+            if (serverWorld != null) world = serverWorld;
+        }
+
+        if (world instanceof String) {
+            var serverWorld = Bukkit.getWorld(new Key((String) world).getValue());
             if (serverWorld != null) world = serverWorld;
         }
 

--- a/implementations/sponge-8.0.0/src/main/java/de/bluecolored/bluemap/sponge/SpongePlugin.java
+++ b/implementations/sponge-8.0.0/src/main/java/de/bluecolored/bluemap/sponge/SpongePlugin.java
@@ -232,6 +232,11 @@ public class SpongePlugin implements ServerInterface {
         if (world instanceof Path)
             return getWorld((Path) world);
 
+        if (world instanceof String) {
+            ResourceKey resourceKey = ResourceKey.resolve((String) world);
+            if (resourceKey != null) world = resourceKey;
+        }
+
         if (world instanceof ResourceKey) {
             var serverWorld = Sponge.server().worldManager().world((ResourceKey) world).orElse(null);
             if (serverWorld != null) world = serverWorld;

--- a/implementations/sponge-9.0.0/src/main/java/de/bluecolored/bluemap/sponge/SpongePlugin.java
+++ b/implementations/sponge-9.0.0/src/main/java/de/bluecolored/bluemap/sponge/SpongePlugin.java
@@ -232,6 +232,11 @@ public class SpongePlugin implements ServerInterface {
         if (world instanceof Path)
             return getWorld((Path) world);
 
+        if (world instanceof String) {
+            ResourceKey resourceKey = ResourceKey.resolve((String) world);
+            if (resourceKey != null) world = resourceKey;
+        }
+
         if (world instanceof ResourceKey) {
             var serverWorld = Sponge.server().worldManager().world((ResourceKey) world).orElse(null);
             if (serverWorld != null) world = serverWorld;


### PR DESCRIPTION
Most implementations already support getting the world by implementation-specific resource location, but the string version is often more convenient when trying to avoid these implementation details. This PR implements that functionality.