### PR TITLE
webserver.conf: Restore "ip" configuration value in the default configuration template that was erroneously removed during the configuration system refactor.

### DIFF
--- a/BlueMapCommon/src/main/resources/de/bluecolored/bluemap/config/webserver.conf
+++ b/BlueMapCommon/src/main/resources/de/bluecolored/bluemap/config/webserver.conf
@@ -13,6 +13,13 @@ enabled: true
 # Default is "bluemap/web"
 webroot: "${webroot}"
 
+# The IP address that the webserver will bind to.
+# The default value of "0.0.0.0" will bind to all available addresses, allowing the webserver to be accessed by any other machine.
+# If you want the webserver to ONLY be able to be accessed from your local machine, use "127.0.0.1" or "localhost".
+# This is useful if you want to put the BlueMap webserver behind a reverse proxy, such as lighttpd or nginx.
+# Default is "0.0.0.0"
+ip: "0.0.0.0"
+
 # The port that the webserver listens to.
 # Default is 8100
 port: 8100


### PR DESCRIPTION
webserver.conf: Restore "ip" configuration value in the default configuration template that was erroneously removed during the configuration system refactor in commit e555d558b7b9d93d4c10f30bec9922fce272c5b3.

This allows users to bind the BlueMap webserver to `127.0.0.1` again, which is useful for reverse proxy setups.