### PR TITLE
Improve Docker image tags

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -62,10 +62,13 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
+          # Always tagged as the pushed branch (ex. master)
+          # For releases: latest, full version and major version (ex. latest, v3.3 and v3)
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
             type=raw,value={{branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=match,pattern=v\d+,group=0,enable=${{ startsWith(github.ref, 'refs/tags/') }}
           flavor: |
             latest=false
       - name: Build and push


### PR DESCRIPTION
Use latest release instead of latest commit for the latest tag.
Add a major release tag (ex. v3) to allow for automated upgrades between minor versions.