### PR TITLE
More accurate player head layers

### DIFF
--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/plugin/skins/PlayerSkin.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/plugin/skins/PlayerSkin.java
@@ -83,19 +83,21 @@ public class PlayerSkin {
     }
 
     public BufferedImage createHead(BufferedImage skinTexture) {
-        BufferedImage head = new BufferedImage(8,  8, skinTexture.getType());
+        BufferedImage head;
 
         BufferedImage layer1 = skinTexture.getSubimage(8, 8, 8, 8);
         BufferedImage layer2 = skinTexture.getSubimage(40, 8, 8, 8);
 
         try {
+            head = new BufferedImage(48,  48, BufferedImage.TYPE_INT_ARGB);
             Graphics2D g = head.createGraphics();
-            g.drawImage(layer1, 0, 0, null);
-            g.drawImage(layer2, 0, 0, null);
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+            g.drawImage(layer1, 4, 4, 40, 40, null);
+            g.drawImage(layer2, 0, 0, 48, 48, null);
         } catch (Throwable t) { // There might be problems with headless servers when loading the graphics class, so we catch every exception and error on purpose here
             Logger.global.noFloodWarning("headless-graphics-fail",
                     "Could not access Graphics2D to render player-skin texture. Try adding '-Djava.awt.headless=true' to your startup flags or ignore this warning.");
-
+            head = new BufferedImage(8, 8, skinTexture.getType());
             layer1.copyData(head.getRaster());
         }
 


### PR DESCRIPTION
I have noticed that the top layer of player heads is just overlaid at the same size as the bottom layer. This effectively just replaces the bottom pixels and doesn't really look like it would ingame.
To improve this, the bottom layer is scaled up 5x and the top layer 6x, making each pixel of the top layer 1.2x the size of a bottom layer pixel.
With the transparent background, this also properly reflects things like hats or hair on the top layer as slightly larger than the actual head itself.
Example screenshot of the Webapp: [https://imgur.com/1IJekXI](https://imgur.com/1IJekXI)
The created image itself: [https://imgur.com/fhqWs6H](https://imgur.com/fhqWs6H)