### PR TITLE
fix: Scrolling to zoom in embedded map causes containing page to scroll

### DIFF
--- a/BlueMapCommon/webapp/src/js/controls/freeflight/FreeFlightControls.js
+++ b/BlueMapCommon/webapp/src/js/controls/freeflight/FreeFlightControls.js
@@ -78,7 +78,7 @@ export class FreeFlightControls {
         this.target.addEventListener("contextmenu", this.onContextMenu);
         this.target.addEventListener("mousedown", this.onMouseDown);
         this.target.addEventListener("mouseup", this.onMouseUp);
-        window.addEventListener("wheel", this.onWheel, {passive: true});
+        window.addEventListener("wheel", this.onWheel, {passive: false});
     }
 
     stop() {
@@ -134,6 +134,8 @@ export class FreeFlightControls {
     }
 
     onWheel = evt => {
+        evt.preventDefault();
+
         let delta = evt.deltaY;
         if (evt.deltaMode === WheelEvent.DOM_DELTA_PIXEL) delta *= 0.01;
         if (evt.deltaMode === WheelEvent.DOM_DELTA_LINE) delta *= 0.33;

--- a/BlueMapCommon/webapp/src/js/controls/map/mouse/MouseZoomControls.js
+++ b/BlueMapCommon/webapp/src/js/controls/map/mouse/MouseZoomControls.js
@@ -48,7 +48,7 @@ export class MouseZoomControls {
     start(manager) {
         this.manager = manager;
 
-        this.target.addEventListener("wheel", this.onMouseWheel, {passive: true});
+        this.target.addEventListener("wheel", this.onMouseWheel, {passive: false});
     }
 
     stop() {
@@ -82,6 +82,8 @@ export class MouseZoomControls {
      * @param evt {WheelEvent}
      */
     onMouseWheel = evt => {
+        evt.preventDefault();
+
         let delta = evt.deltaY;
         if (evt.deltaMode === WheelEvent.DOM_DELTA_PIXEL) delta *= 0.01;
         if (evt.deltaMode === WheelEvent.DOM_DELTA_LINE) delta *= 0.33;


### PR DESCRIPTION
If you embed BlueMap in another page and scroll to zoom or change speed the containing page will also be scrolled. Preventing default wheel event for each appears to resolve the issue