### PR TITLE
Modify setFrozen behavior

### DIFF
--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/api/BlueMapMapImpl.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/api/BlueMapMapImpl.java
@@ -109,8 +109,13 @@ public class BlueMapMapImpl implements BlueMapMap {
 
     @Override
     public synchronized void setFrozen(boolean frozen) {
-        if (isFrozen()) unfreeze();
-        else freeze();
+        if (frozen != isFrozen()) {
+            if (frozen) {
+                freeze();
+            } else {
+                unfreeze();
+            }
+        }
     }
 
     private synchronized void unfreeze() {


### PR DESCRIPTION
Originally, `setFrozen` method behaves simply reversing map frozen state regardless of parameter.