### PR TITLE
Allow the build to work in cases where the current repo has no tags

### DIFF
--- a/BlueMapCore/build.gradle.kts
+++ b/BlueMapCore/build.gradle.kts
@@ -28,8 +28,8 @@ fun String.runCommand(): String = ProcessBuilder(split("\\s(?=(?:[^'\"`]*(['\"`]
 
 val gitHash = "git rev-parse --verify HEAD".runCommand()
 val clean = "git status --porcelain".runCommand().isEmpty()
-val lastTag = "git describe --tags --abbrev=0".runCommand()
-val lastVersion = lastTag.substring(1) // remove the leading 'v'
+val lastTag = if ("git tag".runCommand().isEmpty()) "" else "git describe --tags --abbrev=0".runCommand()
+val lastVersion = if (lastTag.isEmpty()) "dev" else lastTag.substring(1) // remove the leading 'v'
 val commits = "git rev-list --count $lastTag..HEAD".runCommand()
 println("Git hash: $gitHash" + if (clean) "" else " (dirty)")
 


### PR DESCRIPTION
When forking the project on GitHub there is an option to only fork the main repo branch. This means that the forked repo will not have any tags in it which currently causes the build system to fail.

This change adds a fallback in the case that there are no tags to building a version named "-dev-dirty".