### PR TITLE
Add port-in-use check

### DIFF
--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/plugin/Plugin.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/plugin/Plugin.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
@@ -194,6 +195,9 @@ public class Plugin implements ServerEventListener {
                     } catch (UnknownHostException ex) {
                         throw new ConfigurationException("BlueMap failed to resolve the ip in your webserver-config.\n" +
                                 "Check if that is correctly configured.", ex);
+                    } catch (BindException ex) {
+                        throw new ConfigurationException("BlueMap failed to bind to the configured address.\n" +
+                                "This usually happens when the configured port (" + webserverConfig.getPort() + ") is already in use by some other program.", ex);
                     } catch (IOException ex) {
                         throw new ConfigurationException("BlueMap failed to initialize the webserver.\n" +
                                 "Check your webserver-config if everything is configured correctly.\n" +


### PR DESCRIPTION
This PR adds an extra catch when the webserver tries to bind to a specific address and fails.
A bit of extra explanation is included to guide users to double-check their port.

In use, it looks like this:
```
> java -jar BlueMap-3.14-3-dirty-cli.jar -w
[INFO] Starting webserver ...
[INFO] Initializing Storage: 'file' (Type: FILE)
[WARNING] 
################################
 There is a problem with your BlueMap setup!
 BlueMap failed to bind to the configured address.
 This usually happens when the configured port (8100) is already in use by some other program.
################################
[ERROR] Detailed error:
de.bluecolored.bluemap.common.config.ConfigurationException: java.net.BindException: Address already in use
	at de.bluecolored.bluemap.cli.BlueMapCLI.startWebserver(BlueMapCLI.java:221)
	at de.bluecolored.bluemap.cli.BlueMapCLI.main(BlueMapCLI.java:322)
Caused by: java.net.BindException: Address already in use
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:459)
	at java.base/sun.nio.ch.Net.bind(Net.java:448)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
	at java.base/java.nio.channels.ServerSocketChannel.bind(ServerSocketChannel.java:162)
	at de.bluecolored.bluemap.common.web.http.Server.bind(Server.java:28)
	at de.bluecolored.bluemap.cli.BlueMapCLI.startWebserver(BlueMapCLI.java:211)
	... 1 more
```