### PR TITLE
Expose more JavaScript classes

### DIFF
--- a/BlueMapCommon/webapp/src/js/BlueMap.js
+++ b/BlueMapCommon/webapp/src/js/BlueMap.js
@@ -22,41 +22,85 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import {Object3D} from "three";
+import { Object3D } from "three";
 
-export * from "./MapViewer";
+export * as Three from "three";
 
+export * from "./controls/freeflight/FreeFlightControls";
+export * from "./controls/freeflight/keyboard/KeyHeightControls";
+// class name conflicts with map controls
+export { KeyMoveControls as FreeFlightKeyMoveControls } from "./controls/freeflight/keyboard/KeyMoveControls";
+export { MouseAngleControls as FreeFlightMouseAngleControls } from "./controls/freeflight/mouse/MouseAngleControls";
+export { MouseRotateControls as FreeFlightMouseRotateControls } from "./controls/freeflight/mouse/MouseRotateControls";
+export * from "./controls/freeflight/touch/TouchPanControls";
+
+export * from "./controls/map/MapControls";
+export * from "./controls/map/MapHeightControls";
+export * from "./controls/map/keyboard/KeyAngleControls";
+export { KeyMoveControls as MapKeyMoveControls } from "./controls/map/keyboard/KeyMoveControls";
+export * from "./controls/map/keyboard/KeyRotateControls";
+export * from "./controls/map/keyboard/KeyZoomControls";
+export { MouseAngleControls as MapMouseAngleControls } from "./controls/map/mouse/MouseAngleControls";
+export * from "./controls/map/mouse/MouseMoveControls";
+export { MouseRotateControls as MapMouseRotateControls } from "./controls/map/mouse/MouseRotateControls";
+export * from "./controls/map/mouse/MouseZoomControls";
+export * from "./controls/map/touch/TouchAngleControls";
+export * from "./controls/map/touch/TouchMoveControls";
+export * from "./controls/map/touch/TouchRotateControls";
+export * from "./controls/map/touch/TouchZoomControls";
+
+export * from "./controls/ControlsManager";
+export * from "./controls/KeyCombination";
+
+export * from "./map/LowresTileLoader";
 export * from "./map/Map";
 export * from "./map/Tile";
 export * from "./map/TileLoader";
 export * from "./map/TileManager";
 export * from "./map/TileMap";
+export * from "./map/hires/HiresFragmentShader";
+export * from "./map/hires/HiresVertexShader";
+export * from "./map/lowres/LowresFragmentShader";
+export * from "./map/lowres/LowresVertexShader";
 
 export * from "./markers/ExtrudeMarker";
 export * from "./markers/HtmlMarker";
 export * from "./markers/LineMarker";
 export * from "./markers/Marker";
+export * from "./markers/MarkerFillFragmentShader";
+export * from "./markers/MarkerFillVertexShader";
 export * from "./markers/MarkerManager";
 export * from "./markers/MarkerSet";
-export * from "./markers/PlayerMarkerSet";
+export * from "./markers/NormalMarkerManager";
 export * from "./markers/ObjectMarker";
 export * from "./markers/PlayerMarker";
+export * from "./markers/PlayerMarkerManager";
+export * from "./markers/PlayerMarkerSet";
 export * from "./markers/PoiMarker";
 export * from "./markers/ShapeMarker";
 
-export * from "./controls/map/MapControls";
-export * from "./controls/freeflight/FreeFlightControls";
+export * from "./skybox/SkyFragmentShader";
+export * from "./skybox/SkyVertexShader";
+export * from "./skybox/SkyboxScene";
 
+export * from "./util/CSS2DRenderer";
 export * from "./util/CombinedCamera";
+export * from "./util/LineShader";
+export * from "./util/Stats";
 export * from "./util/Utils";
+
+export * from "./BlueMapApp";
+export * from "./MainMenu";
+export * from "./MapViewer";
+export * from "./PopupMarker";
+export * from "./Utils";
 
 /**
  * @param event {object}
  * @return {boolean} - whether the event has been consumed (true) or not (false)
  */
-Object3D.prototype.onClick = function(event) {
-
-    if (this.parent){
+Object3D.prototype.onClick = function (event) {
+    if (this.parent) {
         if (!Array.isArray(event.eventStack)) event.eventStack = [];
         event.eventStack.push(this);
 

--- a/BlueMapCommon/webapp/src/main.js
+++ b/BlueMapCommon/webapp/src/main.js
@@ -25,6 +25,7 @@
 
 import * as Vue from 'vue';
 import App from './App.vue';
+import * as BlueMap from "./js/BlueMap";
 import {BlueMapApp} from "./js/BlueMapApp";
 import {i18nModule, loadLanguageSettings} from "./i18n";
 
@@ -38,6 +39,7 @@ async function load() {
   try {
     const bluemap = new BlueMapApp(document.getElementById("map-container"));
     window.bluemap = bluemap;
+    window.BlueMap = BlueMap;
 
     // init vue
     const vue = Vue.createApp(App, {


### PR DESCRIPTION
With the lack of a proper JavaScript API for addons, it might be useful to just expose all the classes in the global namespace for usage and code injection.