### PR TITLE
Fix tall non-animated textures getting cut off vertically

### DIFF
--- a/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/resources/resourcepack/ResourcePack.java
+++ b/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/resources/resourcepack/ResourcePack.java
@@ -374,7 +374,7 @@ public class ResourcePack {
                         if (!usedTextures.contains(resourcePath)) return null; // don't load unused textures
 
                         try (InputStream in = Files.newInputStream(file)) {
-                            return Texture.from(resourcePath, ImageIO.read(in));
+                            return Texture.from(resourcePath, ImageIO.read(in), Files.exists(file.resolveSibling(file.getFileName() + ".mcmeta")));
                         }
                     }, textures));
 

--- a/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/resources/resourcepack/texture/Texture.java
+++ b/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/resources/resourcepack/texture/Texture.java
@@ -99,8 +99,12 @@ public class Texture {
     }
 
     public static Texture from(ResourcePath<Texture> resourcePath, BufferedImage image) throws IOException {
+        return from(resourcePath, image, true);
+    }
+
+    public static Texture from(ResourcePath<Texture> resourcePath, BufferedImage image, boolean animated) throws IOException {
         //crop off animation frames
-        if (image.getHeight() > image.getWidth()){
+        if (animated && image.getHeight() > image.getWidth()){
             image = image.getSubimage(0, 0, image.getWidth(), image.getWidth());
         }
 


### PR DESCRIPTION
Added a simple check that queries existence of `.mcmeta` file for the texture before cutting it to the first frame.

Before:
![2023-08-23_21-29-04_b04af9aa-04ce-4cd6-b5ab-de7102e4f7ca](https://github.com/BlueMap-Minecraft/BlueMap/assets/5104603/4819088a-7c99-4926-bb87-242261ee905b)
![2023-08-23_21-28-57_08a7a291-7f7e-4756-97fd-98740d7435fe](https://github.com/BlueMap-Minecraft/BlueMap/assets/5104603/4cf63b04-453b-4dce-b508-8634dddaa606)

After:
![2023-08-23_22-05-10_8a4c0a6e-4ce1-41c2-9e92-d4056e6d5a33](https://github.com/BlueMap-Minecraft/BlueMap/assets/5104603/426acc96-3e06-4a9e-9f0f-b6967b68dfc5)
![2023-08-23_22-05-22_a9771333-b7d5-4ac6-817b-42dfc521ee10](https://github.com/BlueMap-Minecraft/BlueMap/assets/5104603/b961baf2-e067-4e00-8a54-cc5917c29ab1)
