### PR TITLE
Log user-added Scrips & Styles when they load in

### DIFF
--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/WebFilesManager.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/WebFilesManager.java
@@ -203,8 +203,17 @@ public class WebFilesManager {
         }
 
         public void addFrom(WebappConfig config) {
-            this.scripts.addAll(config.getScripts());
-            this.styles.addAll(config.getStyles());
+            Set<String> scripts = config.getScripts();
+            for (String script : scripts) {
+                this.scripts.add(script);
+                Logger.global.logDebug("Registering script from Webapp Config: " + script);
+            }
+
+            Set<String> styles = config.getStyles();
+            for (String style : styles) {
+                this.styles.add(style);
+                Logger.global.logDebug("Registering style from Webapp Config: " + style);
+            }
         }
 
     }

--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/api/WebAppImpl.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/api/WebAppImpl.java
@@ -26,6 +26,7 @@ package de.bluecolored.bluemap.common.api;
 
 import de.bluecolored.bluemap.api.WebApp;
 import de.bluecolored.bluemap.common.plugin.Plugin;
+import de.bluecolored.bluemap.core.logger.Logger;
 import de.bluecolored.bluemap.core.util.FileHelper;
 
 import javax.imageio.ImageIO;
@@ -68,11 +69,13 @@ public class WebAppImpl implements WebApp {
 
     @Override
     public void registerScript(String url) {
+        Logger.global.logDebug("Registering script from API: " + url);
         plugin.getBlueMap().getWebFilesManager().getScripts().add(url);
     }
 
     @Override
     public void registerStyle(String url) {
+        Logger.global.logDebug("Registering style from API: " + url);
         plugin.getBlueMap().getWebFilesManager().getStyles().add(url);
     }
 

--- a/BlueMapCommon/webapp/src/js/BlueMapApp.js
+++ b/BlueMapCommon/webapp/src/js/BlueMapApp.js
@@ -146,6 +146,7 @@ export class BlueMapApp {
             let styleElement = document.createElement("link");
             styleElement.rel = "stylesheet";
             styleElement.href = styleUrl;
+            alert(this.events, "Loading style: " + styleUrl, "fine");
             document.head.appendChild(styleElement);
         }
 
@@ -189,6 +190,7 @@ export class BlueMapApp {
         if (this.settings.scripts) for (let scriptUrl of this.settings.scripts) {
             let scriptElement = document.createElement("script");
             scriptElement.src = scriptUrl;
+            alert(this.events, "Loading script: " + scriptUrl, "fine");
             document.body.appendChild(scriptElement);
         }
     }


### PR DESCRIPTION
This makes it easier for 3rd party developers to verify that their code is properly registering their snippets.
It also helps normal users who use custom snippets, of course.