### PR TITLE
Make TextureVariable references align with game behaviour

### DIFF
--- a/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/resources/resourcepack/blockmodel/TextureVariable.java
+++ b/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/resources/resourcepack/blockmodel/TextureVariable.java
@@ -140,13 +140,16 @@ public class TextureVariable {
         public TextureVariable read(JsonReader in) throws IOException {
             String value = in.nextString();
             if (value.isEmpty()) throw new IOException("Can't parse an empty String into a TextureVariable");
+
             if (value.charAt(0) == '#') {
                 return new TextureVariable(value.substring(1));
             } else {
+                if (!(value.contains(":") || value.contains("/"))) {
+                    return new TextureVariable(value);
+                }
+
                 return new TextureVariable(new ResourcePath<>(value));
             }
         }
-
     }
-
 }


### PR DESCRIPTION
While the current implementation of reference handling in this class was the correct way to go (only handling texture names starting with # as references), the game is happy to accept references without a leading hashtag, since it just chops it off and continues on the same code path regardless.

This commit makes the reference handling in BlueMap align with this behaviour, potentially allowing "broken" models to render as they do in game.

This method works for reference resolving, since if a string passed into the texture field contains a ':' then it must be a namespaced key, and if it contains a '/' it has to be a resource key, because the 'minecraft' namespace is implied in these cases. The other way around, if someone were to pass in a string like 'oak_planks', it is safe to assume it is a reference, since the implied resource key would be 'minecraft:oak_planks', but textures aren't at the root level in that namespace.