### PR TITLE
Update to latest SpongeAPI 11.0.0

### DIFF
--- a/implementations/sponge/build.gradle.kts
+++ b/implementations/sponge/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 }
 
 sponge {
-	apiVersion("10.0.0")
+	apiVersion("11.0.0")
 	license("MIT")
 	loader {
 		name(PluginLoaders.JAVA_PLAIN)
@@ -52,7 +52,6 @@ sponge {
 			description("Lead Developer")
 		}
 		dependency("spongeapi") {
-			version("10.0.0")
 			optional(false)
 		}
 	}

--- a/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/EventForwarder.java
+++ b/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/EventForwarder.java
@@ -43,7 +43,7 @@ public class EventForwarder {
     }
 
     @Listener(order = Order.POST)
-    public void onPlayerLeave(ServerSideConnectionEvent.Disconnect evt) {
+    public void onPlayerLeave(ServerSideConnectionEvent.Leave evt) {
         listener.onPlayerJoin(evt.player().uniqueId());
     }
 

--- a/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/SpongePlugin.java
+++ b/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/SpongePlugin.java
@@ -184,7 +184,7 @@ public class SpongePlugin implements Server {
     }
 
     @Listener
-    public void onPlayerLeave(ServerSideConnectionEvent.Disconnect evt) {
+    public void onPlayerLeave(ServerSideConnectionEvent.Leave evt) {
         UUID playerUUID = evt.player().uniqueId();
         onlinePlayerMap.remove(playerUUID);
         synchronized (onlinePlayerList) {


### PR DESCRIPTION
for that it also does:

* ~~update the sponge module to Java 21+~~
* ~~update the shadow plugin in sponge to 8.1.1 (for Java 21 support)~~
* ~~update the sponge gradle plugin to 2.2.0~~
* Replace `ServerSideConnectionEvent.Disconnect` by `ServerSideConnectionEvent.Leave`
* ~~Remove the usage of `GameModes.NOT_SET`~~
* ~~comment-in the light code as it is implemented in sponge these days~~

The API update was necessary now, because SpongeAPI finally made a breaking API change that affects BlueMap.

~~I'd argue this cannot be merged as-is because it currently depends on an unreleased version of the SpongeAPI (`11.0.0-SNAPSHOT`). I brought the lack of releases up with the sponge team, but not sure when a release will be available, probably not very soon.~~ In the meantime I'll maintain my fork/this PR as necessary.

~~What are your thoughts on how to integrated this? I considered duplicating the sponge module into a sponge-11 module as done by other implementations.~~