### PR TITLE
updateMap will be automatically triggered on page reload 

### DIFF
--- a/BlueMapCommon/webapp/src/components/Menu/MainMenu.vue
+++ b/BlueMapCommon/webapp/src/components/Menu/MainMenu.vue
@@ -52,13 +52,6 @@ export default {
       markers: this.$bluemap.mapViewer.markers.data,
     }
   },
-  mounted() {
-    // Update the map when the page is reloaded / refreshed because it's probably a troubleshooting step
-    const [entry] = performance.getEntriesByType("navigation");
-    if (entry.type === "reload") {
-      this.$bluemap.updateMap();
-    }
-  },
   methods: {
     goFullscreen() {
       document.body.requestFullscreen();

--- a/BlueMapCommon/webapp/src/components/Menu/MainMenu.vue
+++ b/BlueMapCommon/webapp/src/components/Menu/MainMenu.vue
@@ -52,6 +52,13 @@ export default {
       markers: this.$bluemap.mapViewer.markers.data,
     }
   },
+  mounted() {
+    // Update the map when the page is reloaded / refreshed because it's probably a troubleshooting step
+    const [entry] = performance.getEntriesByType("navigation");
+    if (entry.type === "reload") {
+      this.$bluemap.updateMap();
+    }
+  },
   methods: {
     goFullscreen() {
       document.body.requestFullscreen();

--- a/BlueMapCommon/webapp/src/js/BlueMapApp.js
+++ b/BlueMapCommon/webapp/src/js/BlueMapApp.js
@@ -598,7 +598,12 @@ export class BlueMapApp {
             return;
         }
 
-        this.mapViewer.clearTileCache(this.loadUserSetting("tileCacheHash", this.mapViewer.tileCacheHash));
+        // Only reuse the user's tile cash hash if the current browser navigation event is not a reload.
+        // If it's a reload, we assume the user is troubleshooting and actually wants to refresh the map.
+        const [entry] = performance.getEntriesByType("navigation");
+        if (entry.type != "reload") {
+            this.mapViewer.clearTileCache(this.loadUserSetting("tileCacheHash", this.mapViewer.tileCacheHash));
+        }
 
         this.mapViewer.superSampling = this.loadUserSetting("superSampling", this.mapViewer.data.superSampling);
         this.mapViewer.data.loadedHiresViewDistance = this.loadUserSetting("hiresViewDistance", this.mapViewer.data.loadedHiresViewDistance);


### PR DESCRIPTION
As suggested in this [Discord message](https://discord.com/channels/665868367416131594/751804128749027421/1259804226645921863), this PR adds a mounted lifecycle hook to the MainMenu component in order to update the map when the page is reloaded or refreshed using the [PerformanceNavigationTiming: type property](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type).

This will help users who are trying to troubleshoot missing parts of the map by refreshing the map instead of using the cached tiles.

Feedback on this implementation is greatly appreciated as I'm new to Vue.