### PR TITLE
Support the live daylight cycle

### DIFF
--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/live/LiveBrightnessDataSupplier.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/live/LiveBrightnessDataSupplier.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of BlueMap, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Blue (Lukas Rieger) <https://bluecolored.de>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package de.bluecolored.bluemap.common.live;
+
+import com.google.gson.stream.JsonWriter;
+import de.bluecolored.bluemap.common.serverinterface.Server;
+import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class LiveBrightnessDataSupplier implements Supplier<String> {
+
+    private final Server server;
+
+    public LiveBrightnessDataSupplier(Server server) {
+        this.server = server;
+    }
+
+    @Override
+    public String get() {
+        String dimensionName;
+        Key dimension;
+
+        try (StringWriter jsonString = new StringWriter();
+            JsonWriter json = new JsonWriter(jsonString)) {
+            
+
+            json.beginObject();
+
+            json.name("brightness").beginArray();
+            for (Map.Entry<Key, Integer> entry : this.server.getSkyBrightness().entrySet()) {
+                dimension = entry.getKey();
+                dimensionName = dimension.getNamespace().equals("minecraft") ? 
+                    dimension.getValue() : dimension.getFormatted();
+                json.beginObject();
+                json.name("dimension").value(dimensionName);
+                json.name("val").value(entry.getValue());
+                json.endObject();
+            }
+            json.endArray();
+
+            json.endObject();
+
+            json.flush();
+            return jsonString.toString();
+        } catch (IOException ex) {
+            Logger.global.logError("Failed to write live/brightness json!", ex);
+            return "BlueMap - Exception handling this request";
+        }
+    }
+
+}

--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/serverinterface/Server.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/serverinterface/Server.java
@@ -28,10 +28,12 @@ import de.bluecolored.bluemap.common.debug.DebugDump;
 import de.bluecolored.bluemap.core.util.Tristate;
 import de.bluecolored.bluemap.core.world.World;
 import de.bluecolored.bluemap.core.world.mca.MCAWorld;
+import de.bluecolored.bluemap.core.util.Key;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 public interface Server {
@@ -98,6 +100,9 @@ public interface Server {
      */
     @DebugDump
     Collection<Player> getOnlinePlayers();
+
+    @DebugDump
+    Map<Key, Integer> getSkyBrightness();
 
     /**
      * Registers a ServerEventListener, every method of this interface should be called on the specified events

--- a/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/web/MapRequestHandler.java
+++ b/BlueMapCommon/src/main/java/de/bluecolored/bluemap/common/web/MapRequestHandler.java
@@ -27,6 +27,7 @@ package de.bluecolored.bluemap.common.web;
 import de.bluecolored.bluemap.common.config.PluginConfig;
 import de.bluecolored.bluemap.common.live.LiveMarkersDataSupplier;
 import de.bluecolored.bluemap.common.live.LivePlayersDataSupplier;
+import de.bluecolored.bluemap.common.live.LiveBrightnessDataSupplier;
 import de.bluecolored.bluemap.common.serverinterface.Server;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.map.BmMap;
@@ -43,16 +44,18 @@ public class MapRequestHandler extends RoutingRequestHandler {
     public MapRequestHandler(BmMap map, Server serverInterface, PluginConfig pluginConfig, Predicate<UUID> playerFilter) {
         this(map.getStorage(),
                 createPlayersDataSupplier(map, serverInterface, pluginConfig, playerFilter),
-                new LiveMarkersDataSupplier(map.getMarkerSets()));
+                new LiveMarkersDataSupplier(map.getMarkerSets()),
+                new LiveBrightnessDataSupplier(serverInterface));
     }
 
     public MapRequestHandler(MapStorage mapStorage) {
-        this(mapStorage, null, null);
+        this(mapStorage, null, null, null);
     }
 
     public MapRequestHandler(MapStorage mapStorage,
                              @Nullable Supplier<String> livePlayersDataSupplier,
-                             @Nullable Supplier<String> liveMarkerDataSupplier) {
+                             @Nullable Supplier<String> liveMarkerDataSupplier,
+                             @Nullable Supplier<String> liveBrightnessDataSupplier) {
 
         register(".*", new MapStorageRequestHandler(mapStorage));
 
@@ -65,6 +68,12 @@ public class MapRequestHandler extends RoutingRequestHandler {
         if (liveMarkerDataSupplier != null) {
             register("live/markers\\.json", "", new JsonDataRequestHandler(
                     new CachedRateLimitDataSupplier(liveMarkerDataSupplier,10000)
+            ));
+        }
+
+        if (liveBrightnessDataSupplier != null) {
+            register("live/brightness\\.json", "", new JsonDataRequestHandler(
+                    new CachedRateLimitDataSupplier(liveBrightnessDataSupplier,1000)
             ));
         }
     }

--- a/BlueMapCommon/webapp/public/lang/en.conf
+++ b/BlueMapCommon/webapp/public/lang/en.conf
@@ -53,6 +53,7 @@
     }
     sunlight: "Sunlight"
     ambientLight: "Ambient-Light"
+    liveDaylightCycle: "Live Daylight Cycle"
   }
   resolution: {
     title: "Resolution"

--- a/BlueMapCommon/webapp/src/components/Menu/SettingsMenu.vue
+++ b/BlueMapCommon/webapp/src/components/Menu/SettingsMenu.vue
@@ -11,6 +11,7 @@
               @update="mapViewer.uniforms.sunlightStrength.value = $event; $bluemap.mapViewer.redraw()">{{$t('lighting.sunlight')}}</Slider>
       <Slider :value="mapViewer.uniforms.ambientLight.value" :min="0" :max="1" :step="0.01"
               @update="mapViewer.uniforms.ambientLight.value = $event; $bluemap.mapViewer.redraw()">{{$t('lighting.ambientLight')}}</Slider>
+      <SwitchButton :on="appState.controls.liveDaylightCycle" @action="appState.controls.liveDaylightCycle = !appState.controls.liveDaylightCycle; $bluemap.saveUserSettings()">{{$t('lighting.liveDaylightCycle')}}</SwitchButton>
     </Group>
 
     <Group :title="$t('resolution.title')">

--- a/BlueMapCommon/webapp/src/js/BlueMapApp.js
+++ b/BlueMapCommon/webapp/src/js/BlueMapApp.js
@@ -408,7 +408,6 @@ export class BlueMapApp {
     async updateBrightness() {
         /*
         Fetch the brightness from the server and update the daylight cycle.
-        Returns timeout/1000 for the update loop.
         */
         return new Promise((resolve, reject) => {
             let loader = new FileLoader();

--- a/implementations/fabric-1.18/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.18/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -236,6 +237,15 @@ public class FabricMod implements ModInitializer, Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        for (net.minecraft.server.world.ServerWorld world : serverInstance.getWorlds()) {
+            skyBrightness.put(worlds.get(world).getDimension(), world.getAmbientDarkness());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/fabric-1.19.4/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.19.4/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -236,6 +237,15 @@ public class FabricMod implements ModInitializer, Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        for (net.minecraft.server.world.ServerWorld world : serverInstance.getWorlds()) {
+            skyBrightness.put(worlds.get(world).getDimension(), world.getAmbientDarkness());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/fabric-1.20.5/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.20.5/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -236,6 +237,15 @@ public class FabricMod implements ModInitializer, Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        for (net.minecraft.server.world.ServerWorld world : serverInstance.getWorlds()) {
+            skyBrightness.put(worlds.get(world).getDimension(), world.getAmbientDarkness());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/fabric-1.20/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric-1.20/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -236,6 +237,15 @@ public class FabricMod implements ModInitializer, Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        for (net.minecraft.server.world.ServerWorld world : serverInstance.getWorlds()) {
+            skyBrightness.put(worlds.get(world).getDimension(), world.getAmbientDarkness());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/fabric/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
+++ b/implementations/fabric/src/main/java/de/bluecolored/bluemap/fabric/FabricMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -236,6 +237,15 @@ public class FabricMod implements ModInitializer, Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        for (net.minecraft.server.world.ServerWorld world : serverInstance.getWorlds()) {
+            skyBrightness.put(worlds.get(world).getDimension(), world.getAmbientDarkness());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/forge-1.18.1/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.18.1/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -252,6 +253,16 @@ public class ForgeMod implements Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        Iterable<ServerLevel> levels = serverInstance.getAllLevels();
+        for (ServerLevel level : levels) {
+            skyBrightness.put(worlds.get(level).getDimension(), level.getSkyDarken());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/forge-1.19.4/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.19.4/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -252,6 +253,16 @@ public class ForgeMod implements Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        Iterable<ServerLevel> levels = serverInstance.getAllLevels();
+        for (ServerLevel level : levels) {
+            skyBrightness.put(worlds.get(level).getDimension(), level.getSkyDarken());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/forge-1.20.6/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.20.6/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -257,6 +258,16 @@ public class ForgeMod implements Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        Iterable<ServerLevel> levels = serverInstance.getAllLevels();
+        for (ServerLevel level : levels) {
+            skyBrightness.put(worlds.get(level).getDimension(), level.getSkyDarken());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/forge-1.20/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge-1.20/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -252,6 +253,16 @@ public class ForgeMod implements Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        Iterable<ServerLevel> levels = serverInstance.getAllLevels();
+        for (ServerLevel level : levels) {
+            skyBrightness.put(worlds.get(level).getDimension(), level.getSkyDarken());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/forge/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/forge/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -257,6 +258,16 @@ public class ForgeMod implements Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        Iterable<ServerLevel> levels = serverInstance.getAllLevels();
+        for (ServerLevel level : levels) {
+            skyBrightness.put(worlds.get(level).getDimension(), level.getSkyDarken());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/neoforge/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
+++ b/implementations/neoforge/src/main/java/de/bluecolored/bluemap/forge/ForgeMod.java
@@ -34,6 +34,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -245,6 +246,16 @@ public class ForgeMod implements Server {
                 onlinePlayerList.get(playerUpdateIndex).update();
             }
         }
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        Iterable<ServerLevel> levels = serverInstance.getAllLevels();
+        for (ServerLevel level : levels) {
+            skyBrightness.put(worlds.get(level).getDimension(), level.getSkyDarken());
+        }
+        return skyBrightness;
     }
 
 }

--- a/implementations/paper/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlugin.java
+++ b/implementations/paper/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlugin.java
@@ -258,4 +258,23 @@ public class BukkitPlugin extends JavaPlugin implements Server, Listener {
         );
     }
 
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        for (World world : getServer().getWorlds()) {
+            int darken = 0;
+            long time = world.getTime();
+
+            if (time >= 12100 && time <= 12800) darken = 3;
+            else if (time > 12800 && time <= 13200) darken = 6;
+            else if (time > 13200 && time <= 22700) darken = 11;
+            else if (time > 23000 && time <= 23400) darken = 6;
+            else if (time > 23400 && time <= 23850) darken = 3;
+            else darken = 0;
+
+            skyBrightness.put(worlds.get(world).getDimension(), darken);
+        }
+        return skyBrightness;
+    }
+
 }

--- a/implementations/spigot/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlugin.java
+++ b/implementations/spigot/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlugin.java
@@ -284,4 +284,23 @@ public class BukkitPlugin extends JavaPlugin implements Server, Listener {
         }
     }
 
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        for (World world : getServer().getWorlds()) {
+            int darken = 0;
+            long time = world.getTime();
+
+            if (time >= 12100 && time <= 12800) darken = 3;
+            else if (time > 12800 && time <= 13200) darken = 6;
+            else if (time > 13200 && time <= 22700) darken = 11;
+            else if (time > 23000 && time <= 23400) darken = 6;
+            else if (time > 23400 && time <= 23850) darken = 3;
+            else darken = 0;
+
+            skyBrightness.put(worlds.get(world).getDimension(), darken);
+        }
+        return skyBrightness;
+    }
+
 }

--- a/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/SpongePlugin.java
+++ b/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/SpongePlugin.java
@@ -37,6 +37,7 @@ import de.bluecolored.bluemap.common.serverinterface.ServerEventListener;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.BlueMap;
 import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.util.Key;
 import de.bluecolored.bluemap.sponge.SpongeCommands.SpongeCommandProxy;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.Sponge;
@@ -316,5 +317,24 @@ public class SpongePlugin implements Server {
 
     public static SpongePlugin getInstance() {
         return instance;
+    }
+
+    @Override
+    public Map<Key, Integer> getSkyBrightness() {
+        Map<Key, Integer> skyBrightness = new HashMap<>();
+        for (var world : Sponge.server().worldManager().worlds()) {
+            int darken = 0;
+            long time = world.properties().dayTime().asTicks().ticks() % 24000;
+
+            if (time >= 12100 && time <= 12800) darken = 3;
+            else if (time > 12800 && time <= 13200) darken = 6;
+            else if (time > 13200 && time <= 22700) darken = 11;
+            else if (time > 23000 && time <= 23400) darken = 6;
+            else if (time > 23400 && time <= 23850) darken = 3;
+            else darken = 0;
+
+            skyBrightness.put(worlds.get(world).getDimension(), darken);
+        }
+        return skyBrightness;
     }
 }


### PR DESCRIPTION
## Introduction
Thank you for your amazing project. BlueMap helps me a lot!
Just noticed that the feature is in Ideas board, so I try to implement it. #398
These changes implement the feature of a live daylight cycle on BlueMap webpages. I leverage the Minecraft API to get the ambient darkness of all dimensions and add an HTTP handler to allow frontend to retrieve this data.

## Demo
| Night | Dawn | Day |
|--------|--------|--------|
| ![8d02837c0ac024d74127f7997db35c64](https://github.com/BlueMap-Minecraft/BlueMap/assets/37870767/16ae713d-19a3-4a7f-81d1-3eabed1f7e2e) | ![0301e8c17bf7e7436630777f6564c382](https://github.com/BlueMap-Minecraft/BlueMap/assets/37870767/ef4015a7-deb8-4b91-9e90-eb95956d9df6) | ![d79d4a90344fd588753191702535af61](https://github.com/BlueMap-Minecraft/BlueMap/assets/37870767/320954b7-9404-45a1-8c08-fa5e679297eb) | 

## Details

- For the `forge` and `neoforge` sides, I utilized `level.getSkyDarken()` to get ambient darkness data. This method returns an integer ranging from 0 to 11, where 0 means day and 11 means night.
- The `fabric` side is similar to the `forge` side; I used `world.getAmbientDarkness()`, which has the same effect as `getSkyDarken()`.
- For the `spigot` and `sponge` sides, I couldn't find a similar function, so I used ticks and some hardcoding to implement the feature.
- On the frontend, I added a switch button in the `SettingsMenu`. Users can toggle this button to turn the feature on or off. The frontend will request `/live/brightness.json` every 2 seconds (or every 3 seconds if the request fails) and adjust the `sunlightStrength` value accordingly. The data format is as follows:
  ```json
  {
      "brightness": [
          {
              "dimension": "overworld",
              "val": 3
          },
          {
              "dimension": "the_nether",
              "val": 0
          },
          {
              "dimension": "the_end",
              "val": 0
          }
      ]
  }
  ```
  <img width=300 src="https://github.com/BlueMap-Minecraft/BlueMap/assets/37870767/586eea02-a2a3-4ae3-81bd-3fa148945dee"/>

> *I figured out a way to calculate ambient darkness as shown below, but it requires too many computational resources, so I didn't implement it for the `spigot` and `sponge` sides.
> <img src="https://github.com/BlueMap-Minecraft/BlueMap/assets/37870767/903a8599-b9e6-4fd8-908c-a23499454653" width=300/>

## Test coverage
I tested forge, fabric, paper, and sponge on versions 1.19-1.20, and the feature works well. I can make more tests if you think this PR would be helpful for you.

If you find any errors or shortcomings in these changes, I will fix them as soon as possible! And the branch is allow edits by maintainers, you can make any improvement.