### PR TITLE
Load hanging signs, too

### DIFF
--- a/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/world/block/entity/BlockEntityType.java
+++ b/BlueMapCore/src/main/java/de/bluecolored/bluemap/core/world/block/entity/BlockEntityType.java
@@ -35,11 +35,13 @@ import java.util.Map;
 public interface BlockEntityType extends Keyed, BlockEntityLoader {
 
     BlockEntityType SIGN = new Impl(Key.minecraft("sign"), SignBlockEntity::new);
+    BlockEntityType HANGING_SIGN = new Impl(Key.minecraft("hanging_sign"), SignBlockEntity::new);
     BlockEntityType SKULL = new Impl(Key.minecraft("skull"), SkullBlockEntity::new);
     BlockEntityType BANNER = new Impl(Key.minecraft("banner"), BannerBlockEntity::new);
 
     Registry<BlockEntityType> REGISTRY = new Registry<>(
             SIGN,
+            HANGING_SIGN,
             SKULL,
             BANNER
     );


### PR DESCRIPTION
BlueMap only loads normal signs, but not hanging signs.

Sneak preview to what I'm doing with it:
![image](https://github.com/user-attachments/assets/fab03043-cc72-4a3b-9157-9d54a52b6003)
