### PR TITLE
add logs the detailed error message in php

### DIFF
--- a/BlueMapCommon/webapp/public/sql.php
+++ b/BlueMapCommon/webapp/public/sql.php
@@ -150,7 +150,8 @@ if (startsWith($path, "/maps/")) {
         $sql = new PDO("$driver:host=$hostname;port=$port;dbname=$database", $username, $password);
         $sql->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     } catch (PDOException $e ) { 
-        error(500, "Failed to connect to database: ".$e->getMessage());
+        error_log($e->getMessage(), 0); // Logs the detailed error message
+        error(500, "Failed to connect to database");
     }
 
     // provide map-tiles
@@ -201,7 +202,10 @@ if (startsWith($path, "/maps/")) {
                 exit;
             }
 
-        } catch (PDOException $e) { error(500, "Failed to fetch data: ".$e->getMessage()); }
+        } catch (PDOException $e) { 
+            error_log($e->getMessage(), 0);
+            error(500, "Failed to fetch data");
+        }
 
         // no content if nothing found
         http_response_code(204);
@@ -240,7 +244,10 @@ if (startsWith($path, "/maps/")) {
                 send($line["data"]);
                 exit;
             }
-        } catch (PDOException $e) { error(500, "Failed to fetch data: ".$e->getMessage()); }
+        } catch (PDOException $e) { 
+            error_log($e->getMessage(), 0);
+            error(500, "Failed to fetch data");
+        }
     }
 
 }

--- a/BlueMapCommon/webapp/public/sql.php
+++ b/BlueMapCommon/webapp/public/sql.php
@@ -149,7 +149,10 @@ if (startsWith($path, "/maps/")) {
     try {
         $sql = new PDO("$driver:host=$hostname;port=$port;dbname=$database", $username, $password);
         $sql->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    } catch (PDOException $e ) { error(500, "Failed to connect to database"); }
+    } catch (PDOException $e ) { 
+        error_log($e->getMessage(), 0); // Logs the detailed error message
+        error(500, "Failed to connect to database"); 
+    }
 
     // provide map-tiles
     if (startsWith($mapPath, "tiles/")) {

--- a/BlueMapCommon/webapp/public/sql.php
+++ b/BlueMapCommon/webapp/public/sql.php
@@ -150,8 +150,7 @@ if (startsWith($path, "/maps/")) {
         $sql = new PDO("$driver:host=$hostname;port=$port;dbname=$database", $username, $password);
         $sql->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     } catch (PDOException $e ) { 
-        error_log($e->getMessage(), 0); // Logs the detailed error message
-        error(500, "Failed to connect to database"); 
+        error(500, "Failed to connect to database: ".$e->getMessage());
     }
 
     // provide map-tiles
@@ -202,7 +201,7 @@ if (startsWith($path, "/maps/")) {
                 exit;
             }
 
-        } catch (PDOException $e) { error(500, "Failed to fetch data");  }
+        } catch (PDOException $e) { error(500, "Failed to fetch data: ".$e->getMessage()); }
 
         // no content if nothing found
         http_response_code(204);
@@ -241,7 +240,7 @@ if (startsWith($path, "/maps/")) {
                 send($line["data"]);
                 exit;
             }
-        } catch (PDOException $e) { error(500, "Failed to fetch data"); }
+        } catch (PDOException $e) { error(500, "Failed to fetch data: ".$e->getMessage()); }
     }
 
 }


### PR DESCRIPTION
It really takes me time to find out why i can't host web standalone with just "Failed to connect to database".

Then i added the log detail, everything just be cleared: `NOTICE: PHP message: could not find driver`

So I think it's necessary to log err details for solving problems...