### PR TITLE
redirect map and live data requests in the webapp

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/WebFilesManager.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/WebFilesManager.java
@@ -141,6 +141,9 @@ public class WebFilesManager {
         private int lowresSliderDefault = 2000;
         private int lowresSliderMin = 500;
 
+        private String mapDataRoot = "maps/";
+        private String liveDataRoot = "maps/";
+
         private Set<String> maps = new HashSet<>();
         private Set<String> scripts = new HashSet<>();
         private Set<String> styles = new HashSet<>();
@@ -162,6 +165,9 @@ public class WebFilesManager {
             this.lowresSliderMax = config.getLowresSliderMax();
             this.lowresSliderDefault = config.getLowresSliderDefault();
             this.lowresSliderMin = config.getLowresSliderMin();
+
+            this.mapDataRoot = config.getMapDataRoot();
+            this.liveDataRoot = config.getLiveDataRoot();
 
             this.styles.clear();
             this.scripts.clear();

--- a/common/src/main/java/de/bluecolored/bluemap/common/config/WebappConfig.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/WebappConfig.java
@@ -60,6 +60,9 @@ public class WebappConfig {
     private int lowresSliderDefault = 2000;
     private int lowresSliderMin = 500;
 
+    private String mapDataRoot = "maps/";
+    private String liveDataRoot = "maps/";
+
     private Set<String> scripts = new HashSet<>();
     private Set<String> styles = new HashSet<>();
     public boolean isEnabled() {
@@ -124,6 +127,14 @@ public class WebappConfig {
 
     public int getLowresSliderMin() {
         return lowresSliderMin;
+    }
+
+    public String getMapDataRoot() {
+        return mapDataRoot;
+    }
+
+    public String getLiveDataRoot() {
+        return liveDataRoot;
     }
 
     public Set<String> getScripts() {

--- a/common/src/main/resources/de/bluecolored/bluemap/config/webapp.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/webapp.conf
@@ -69,3 +69,11 @@ scripts: [
 styles: [
     #"css/my-custom-style.css"
 ]
+
+# Here you can specify an alternative base url from where all map data is loaded.
+# Default is "maps/"
+#map-data-root: "https://cdn.my-domain.com/mapdata/"
+
+# Here you can specify an alternative base url from where all live data is loaded.
+# Default is "maps/"
+#live-data-root: "https://cdn.my-domain.com/livedata/"

--- a/common/webapp/src/js/BlueMapApp.js
+++ b/common/webapp/src/js/BlueMapApp.js
@@ -71,6 +71,8 @@ export class BlueMapApp {
          *      lowresSliderDefault: number,
          *      lowresSliderMin: number,
          *      startLocation: string,
+         *      mapDataRoot: string,
+         *      liveDataRoot: string,
          *      maps: string[],
          *      scripts: string[],
          *      styles: string[]
@@ -85,8 +87,6 @@ export class BlueMapApp {
         this.mapsMap = new Map();
 
         this.lastCameraMove = 0;
-
-        this.dataUrl = "maps/";
 
         this.mainMenu = reactive(new MainMenu());
 
@@ -300,7 +300,7 @@ export class BlueMapApp {
         // create maps
         if (settings.maps !== undefined){
             let loadingPromises = settings.maps.map(mapId => {
-                let map = new BlueMapMap(mapId, this.dataUrl + mapId + "/", this.loadBlocker, this.mapViewer.events);
+                let map = new BlueMapMap(mapId, settings.mapDataRoot + mapId + "/", settings.liveDataRoot + mapId + "/", this.loadBlocker, this.mapViewer.events);
                 maps.push(map);
 
                 return map.loadSettings(this.mapViewer.tileCacheHash)
@@ -353,7 +353,7 @@ export class BlueMapApp {
         return new Promise((resolve, reject) => {
             let loader = new FileLoader();
             loader.setResponseType("json");
-            loader.load(map.data.dataUrl + "live/players.json?" + generateCacheHash(),
+            loader.load(map.data.liveDataRoot + "live/players.json?" + generateCacheHash(),
                 fileData => {
                     if (!fileData) reject(`Failed to parse '${this.fileUrl}'!`);
                     else resolve(fileData);
@@ -371,7 +371,7 @@ export class BlueMapApp {
         const map = this.mapViewer.map;
         if (!map) return;
 
-        this.playerMarkerManager = new PlayerMarkerManager(this.mapViewer.markers, map.data.dataUrl + "live/players.json", map.data.dataUrl + "assets/playerheads/", this.events);
+        this.playerMarkerManager = new PlayerMarkerManager(this.mapViewer.markers, map.data.liveDataRoot + "live/players.json", map.data.mapDataRoot + "assets/playerheads/", this.events);
         this.playerMarkerManager.setAutoUpdateInterval(0);
         return this.playerMarkerManager.update()
             .then(() => {
@@ -390,7 +390,7 @@ export class BlueMapApp {
         const map = this.mapViewer.map;
         if (!map) return;
 
-        this.markerFileManager = new NormalMarkerManager(this.mapViewer.markers, map.data.dataUrl + "live/markers.json", this.events);
+        this.markerFileManager = new NormalMarkerManager(this.mapViewer.markers, map.data.liveDataRoot + "live/markers.json", this.events);
         return this.markerFileManager.update()
             .then(() => {
                 this.markerFileManager.setAutoUpdateInterval(1000 * 10);

--- a/common/webapp/src/js/map/Map.js
+++ b/common/webapp/src/js/map/Map.js
@@ -45,11 +45,12 @@ export class Map {
 
 	/**
 	 * @param id {string}
-	 * @param dataUrl {string}
+	 * @param mapDataRoot {string}
+	 * @param liveDataRoot {string}
 	 * @param loadBlocker {function: Promise<void>}
 	 * @param events {EventTarget}
 	 */
-	constructor(id, dataUrl, loadBlocker, events = null) {
+	constructor(id, mapDataRoot, liveDataRoot, loadBlocker, events = null) {
 		Object.defineProperty( this, 'isMap', { value: true } );
 
 		this.loadBlocker = loadBlocker;
@@ -58,9 +59,10 @@ export class Map {
 		this.data = reactive({
 			id: id,
 			sorting: 1000000,
-			dataUrl: dataUrl,
-			settingsUrl: dataUrl + "settings.json",
-			texturesUrl: dataUrl + "textures.json",
+			mapDataRoot: mapDataRoot,
+			liveDataRoot: liveDataRoot,
+			settingsUrl: mapDataRoot + "settings.json",
+			texturesUrl: mapDataRoot + "textures.json",
 			name: id,
 			startPos: {x: 0, z: 0},
 			skyColor: new Color(),
@@ -121,12 +123,12 @@ export class Map {
 
                 this.hiresMaterial = this.createHiresMaterial(hiresVertexShader, hiresFragmentShader, uniforms, textures);
 
-                this.hiresTileManager = new TileManager(new TileLoader(`${this.data.dataUrl}tiles/0/`, this.hiresMaterial, this.data.hires, this.loadBlocker, tileCacheHash), this.onTileLoad("hires"), this.onTileUnload("hires"), this.events);
+                this.hiresTileManager = new TileManager(new TileLoader(`${this.data.mapDataRoot}tiles/0/`, this.hiresMaterial, this.data.hires, this.loadBlocker, tileCacheHash), this.onTileLoad("hires"), this.onTileUnload("hires"), this.events);
 				this.hiresTileManager.scene.matrixWorldAutoUpdate = false;
 
                 this.lowresTileManager = [];
 				for (let i = 0; i < this.data.lowres.lodCount; i++) {
-					this.lowresTileManager[i] = new TileManager(new LowresTileLoader(`${this.data.dataUrl}tiles/`, this.data.lowres, i + 1, lowresVertexShader, lowresFragmentShader, uniforms, async () => {}, tileCacheHash), this.onTileLoad("lowres"), this.onTileUnload("lowres"), this.events);
+					this.lowresTileManager[i] = new TileManager(new LowresTileLoader(`${this.data.mapDataRoot}tiles/`, this.data.lowres, i + 1, lowresVertexShader, lowresFragmentShader, uniforms, async () => {}, tileCacheHash), this.onTileLoad("lowres"), this.onTileUnload("lowres"), this.events);
 					this.lowresTileManager[i].scene.matrixWorldAutoUpdate = false;
 				}
 


### PR DESCRIPTION
this pr introduces the capability to change the base-urls from where the webapp loads both mapdata and livedata.
this can be used for a multitude of cdn style scenarios where you want to load mapdata from an external server while serving live data directly.