### PR TITLE
Fix build on macOS

### DIFF
--- a/buildSrc/src/main/kotlin/bluemap.base.gradle.kts
+++ b/buildSrc/src/main/kotlin/bluemap.base.gradle.kts
@@ -16,6 +16,12 @@ repositories {
         content { includeGroup ("org.spigotmc") }
     }
 
+    // lwjgl-freetype-3.3.3-natives-macos-patch.jar is not available on Maven
+    // Central - pull it from the Minecraft library server instead.
+    maven ("https://libraries.minecraft.net") {
+        content { includeModule("org.lwjgl", "lwjgl-freetype") }
+    }
+
     mavenCentral()
     maven ("https://libraries.minecraft.net")
     maven ( "https://maven.minecraftforge.net" )


### PR DESCRIPTION
For whatever reason, `lwjgl-freetype-3.3.3-natives-macos-patch.jar` is not available on Maven Central, resulting the in the following error when building:

```
> Configure project :forge
forge version: 5.4-31-dirty

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':forge'.
> Could not resolve all files for configuration ':forge:_compileJava_1'.
   > Could not find lwjgl-freetype-3.3.3-natives-macos-patch.jar (org.lwjgl:lwjgl-freetype:3.3.3).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/org/lwjgl/lwjgl-freetype/3.3.3/lwjgl-freetype-3.3.3-natives-macos-patch.jar
```

This fix causes the library to be pulled from `https://libraries.minecraft.net` instead.

Fix is based on https://github.com/lucko/spark/commit/49bc094551233e16ebc03d790e14115e63fc01a5