### PR TITLE
Add `equals` and `hashCode` functions for Player class

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/serverinterface/Player.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/serverinterface/Player.java
@@ -29,42 +29,42 @@ import de.bluecolored.bluemap.common.plugin.text.Text;
 
 import java.util.UUID;
 
-public interface Player {
+public abstract class Player {
 
-    UUID getUuid();
+    public abstract UUID getUuid();
 
-    Text getName();
+    public abstract Text getName();
 
-    ServerWorld getWorld();
+    public abstract ServerWorld getWorld();
 
-    Vector3d getPosition();
+    public abstract Vector3d getPosition();
 
     /**
      * x -> pitch, y -> yaw, z -> roll
      */
-    Vector3d getRotation();
+    public abstract Vector3d getRotation();
 
-    int getSkyLight();
+    public abstract int getSkyLight();
 
-    int getBlockLight();
+    public abstract int getBlockLight();
 
     /**
      * Return <code>true</code> if the player is sneaking.
      * <p><i>If the player is offline the value of this method is undetermined.</i></p>
      */
-    boolean isSneaking();
+    public abstract boolean isSneaking();
 
     /**
      * Returns <code>true</code> if the player has an invisibillity effect
      * <p><i>If the player is offline the value of this method is undetermined.</i></p>
      */
-    boolean isInvisible();
+    public abstract boolean isInvisible();
 
     /**
      * Returns <code>true</code> if the player is vanished
      * <p><i>If the player is offline the value of this method is undetermined.</i></p>
      */
-    default boolean isVanished() {
+    public boolean isVanished() {
         return false;
     }
 
@@ -72,6 +72,17 @@ public interface Player {
      * Returns the {@link Gamemode} this player is in
      * <p><i>If the player is offline the value of this method is undetermined.</i></p>
      */
-    Gamemode getGamemode();
+    public abstract Gamemode getGamemode();
 
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Player other = (Player) o;
+        return getUuid().equals(other.getUuid());
+    }
+
+    @Override
+    public int hashCode() {
+        return getUuid().hashCode();
+    }
 }

--- a/implementations/fabric/src/main/java/de/bluecolored/bluemap/fabric/FabricPlayer.java
+++ b/implementations/fabric/src/main/java/de/bluecolored/bluemap/fabric/FabricPlayer.java
@@ -41,7 +41,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class FabricPlayer implements Player {
+public class FabricPlayer extends Player {
 
     private static final Map<GameMode, Gamemode> GAMEMODE_MAP = new EnumMap<>(GameMode.class);
     static {

--- a/implementations/forge/src/main/java/de/bluecolored/bluemap/forge/ForgePlayer.java
+++ b/implementations/forge/src/main/java/de/bluecolored/bluemap/forge/ForgePlayer.java
@@ -42,7 +42,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class ForgePlayer implements Player {
+public class ForgePlayer extends Player {
 
     private static final Map<GameType, Gamemode> GAMEMODE_MAP = new EnumMap<>(GameType.class);
     static {

--- a/implementations/neoforge/src/main/java/de/bluecolored/bluemap/forge/ForgePlayer.java
+++ b/implementations/neoforge/src/main/java/de/bluecolored/bluemap/forge/ForgePlayer.java
@@ -42,7 +42,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class ForgePlayer implements Player {
+public class ForgePlayer extends Player {
 
     private static final Map<GameType, Gamemode> GAMEMODE_MAP = new EnumMap<>(GameType.class);
     static {

--- a/implementations/paper/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlayer.java
+++ b/implementations/paper/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlayer.java
@@ -38,7 +38,7 @@ import org.bukkit.potion.PotionEffectType;
 
 import java.util.*;
 
-public class BukkitPlayer implements Player {
+public class BukkitPlayer extends Player {
 
     private static final Map<GameMode, Gamemode> GAMEMODE_MAP = new EnumMap<>(GameMode.class);
     static {

--- a/implementations/spigot/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlayer.java
+++ b/implementations/spigot/src/main/java/de/bluecolored/bluemap/bukkit/BukkitPlayer.java
@@ -39,7 +39,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class BukkitPlayer implements Player {
+public class BukkitPlayer extends Player {
 
     private static final Map<GameMode, Gamemode> GAMEMODE_MAP = new EnumMap<>(GameMode.class);
     static {

--- a/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/SpongePlayer.java
+++ b/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/SpongePlayer.java
@@ -41,7 +41,7 @@ import org.spongepowered.api.world.LightTypes;
 
 import java.util.*;
 
-public class SpongePlayer implements Player {
+public class SpongePlayer extends Player {
 
     private static final Map<GameMode, Gamemode> GAMEMODE_MAP = new HashMap<>(5);
     static {


### PR DESCRIPTION
It'll be useful for the BMPC rewrite to BMNative, where I need to store the players into a HashSet