### PR TITLE
Add a log message when a resource is missing for block states

### DIFF
--- a/core/src/main/java/de/bluecolored/bluemap/core/map/hires/blockmodel/BlockRendererType.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/map/hires/blockmodel/BlockRendererType.java
@@ -24,6 +24,7 @@
  */
 package de.bluecolored.bluemap.core.map.hires.blockmodel;
 
+import de.bluecolored.bluemap.core.logger.Logger;
 import de.bluecolored.bluemap.core.map.TextureGallery;
 import de.bluecolored.bluemap.core.map.hires.RenderSettings;
 import de.bluecolored.bluemap.core.resources.pack.resourcepack.ResourcePack;
@@ -34,11 +35,14 @@ import de.bluecolored.bluemap.core.world.BlockState;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.HashSet;
+
 public interface BlockRendererType extends Keyed, BlockRendererFactory {
 
     BlockRendererType DEFAULT = new Impl(Key.bluemap("default"), ResourceModelRenderer::new);
     BlockRendererType LIQUID = new Impl(Key.bluemap("liquid"), LiquidModelRenderer::new);
     BlockRendererType MISSING = new Impl(Key.bluemap("missing"), MissingModelRenderer::new);
+    HashSet<BlockState> missingBlockStates = new HashSet<>();
 
     Registry<BlockRendererType> REGISTRY = new Registry<>(
             DEFAULT,
@@ -61,6 +65,9 @@ public interface BlockRendererType extends Keyed, BlockRendererFactory {
      * @return true if this renderer-type can render the provided {@link BlockState} despite missing resources.
      */
     default boolean isFallbackFor(BlockState blockState) {
+        if (missingBlockStates.contains(blockState)) return false;
+        missingBlockStates.add(blockState);
+        Logger.global.logDebug("Missing resources for blockState: " + blockState);
         return false;
     }
 


### PR DESCRIPTION
Each block state is only logged once.
Example (1.13.2 debug world rendered with 1.21.4 resources):
```
[05:16:12 INFO] Start updating 1 maps (25 regions, ~25600 chunks)...
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=0]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=0]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=1]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=1]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=2]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=2]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=3]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=3]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=4]
[05:16:13 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=4]
[05:16:13 DEBUG] Missing blockstate: minecraft:wall_sign[waterlogged=true,facing=north]
[05:16:13 DEBUG] Missing blockstate: minecraft:wall_sign[waterlogged=false,facing=north]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=5]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=5]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=6]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=6]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=7]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=7]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=8]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=8]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=9]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=9]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=10]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=10]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=11]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=11]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=12]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=12]
[05:16:14 DEBUG] Missing blockstate: minecraft:wall_sign[waterlogged=true,facing=south]
[05:16:14 DEBUG] Missing blockstate: minecraft:wall_sign[waterlogged=false,facing=south]
[05:16:14 DEBUG] Missing blockstate: minecraft:wall_sign[waterlogged=true,facing=west]
[05:16:14 DEBUG] Missing blockstate: minecraft:wall_sign[waterlogged=false,facing=west]
[05:16:14 DEBUG] Missing blockstate: minecraft:wall_sign[waterlogged=true,facing=east]
[05:16:14 DEBUG] Missing blockstate: minecraft:wall_sign[waterlogged=false,facing=east]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=13]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=13]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=14]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=14]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=true,rotation=15]
[05:16:14 DEBUG] Missing blockstate: minecraft:sign[waterlogged=false,rotation=15]
```

Feel free to reject this PR if it doesn't match your vision.
I have created it mainly so that it doesn't get lost in time.