### PR TITLE
Actually print the port that was bound instead of one from config

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/web/http/Server.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/http/Server.java
@@ -55,7 +55,7 @@ public abstract class Server extends Thread implements Closeable, Runnable {
         this.server.add(server);
 
         if (checkIfBoundToAllInterfaces(address)) {
-            Logger.global.logInfo("WebServer bound to all network interfaces on port " + ((InetSocketAddress) address).getPort());
+            Logger.global.logInfo("WebServer bound to all network interfaces on port " + ((InetSocketAddress) server.getLocalAddress()).getPort());
         } else {
             Logger.global.logInfo("WebServer bound to: " + server.getLocalAddress());
         }


### PR DESCRIPTION
In the case of binding to port 0, this will print the actually bound port, instead of the `0` that's in the configuration file.