### PR TITLE
feat: Detect when player is within map bounds

### DIFF
--- a/common/webapp/src/components/Menu/MarkerItem.vue
+++ b/common/webapp/src/components/Menu/MarkerItem.vue
@@ -75,7 +75,7 @@ export default {
 
       if (this.marker.type === "player") {
 
-        if (this.marker.foreign) {
+        if (this.marker.foreign || this.marker.outOfBounds) {
           let matchingMap = await this.$bluemap.findPlayerMap(this.marker.playerUuid);
           if (!matchingMap) return;
 

--- a/common/webapp/src/js/map/Map.js
+++ b/common/webapp/src/js/map/Map.js
@@ -65,6 +65,11 @@ export class Map {
 			texturesUrl: mapDataRoot + "/textures.json",
 			name: id,
 			startPos: {x: 0, z: 0},
+			bounds: {
+				x: null,
+				y: null,
+				z: null
+			},
 			skyColor: new Color(),
 			voidColor: new Color(0, 0, 0),
 			ambientLight: 0,
@@ -168,6 +173,16 @@ export class Map {
 				this.data.sorting = Number.isInteger(worldSettings.sorting) ? worldSettings.sorting : this.data.sorting;
 
 				this.data.startPos = {...this.data.startPos, ...vecArrToObj(worldSettings.startPos, true)};
+
+				if (worldSettings.bounds) {
+					const currentBounds = this.data.bounds;
+					['x', 'y', 'z'].forEach(coordinate => {
+						const boundsRange = worldSettings.bounds[coordinate];
+						if (Array.isArray(boundsRange) && boundsRange.length === 2) {
+							currentBounds[coordinate] = [...boundsRange];
+						}
+					});
+				}
 
 				if (worldSettings.skyColor && worldSettings.skyColor.length >= 3) {
 					this.data.skyColor.setRGB(

--- a/common/webapp/src/js/markers/PlayerMarker.js
+++ b/common/webapp/src/js/markers/PlayerMarker.js
@@ -65,6 +65,8 @@ export class PlayerMarker extends Marker {
             this.playerHeadElement.src = "assets/steve.png";
         }, {once: true});
 
+        this.map = window.bluemap.mapViewer.map;
+
         this.add(this.elementObject);
     }
 
@@ -94,6 +96,7 @@ export class PlayerMarker extends Marker {
      *      uuid: string,
      *      name: string,
      *      foreign: boolean,
+     *      outOfBounds: boolean,
      *      position: {x: number, y: number, z: number},
      *      rotation: {yaw: number, pitch: number, roll: number}
      * }}
@@ -155,6 +158,22 @@ export class PlayerMarker extends Marker {
 
         // update world
         this.data.foreign = markerData.foreign;
+
+        // update outOfBounds based on current world bounds
+        if (this.map && this.map.data && this.map.data.bounds) {
+            const bounds = this.map.data.bounds;
+            const currentPos = this.position;
+            this.data.outOfBounds = (
+                currentPos.x < bounds.x[0] ||
+                currentPos.x > bounds.x[1] ||
+                currentPos.y < bounds.y[0] ||
+                currentPos.y > bounds.y[1] ||
+                currentPos.z < bounds.z[0] ||
+                currentPos.z > bounds.z[1]
+            );
+        } else {
+            this.data.outOfBounds = false;
+        }
     }
 
     dispose() {

--- a/common/webapp/src/js/markers/PlayerMarkerSet.js
+++ b/common/webapp/src/js/markers/PlayerMarkerSet.js
@@ -85,8 +85,8 @@ export class PlayerMarkerSet extends MarkerSet {
         // update
         marker.updateFromData(markerData);
 
-        // hide if from different world
-        marker.visible = !markerData.foreign;
+        // hide if from different world or out of bounds
+        marker.visible = !markerData.foreign && !marker.data.outOfBounds;
 
         return marker;
     }

--- a/core/src/main/java/de/bluecolored/bluemap/core/map/MapSettingsSerializer.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/map/MapSettingsSerializer.java
@@ -25,6 +25,7 @@
 package de.bluecolored.bluemap.core.map;
 
 import com.flowpowered.math.vector.Vector2i;
+import com.flowpowered.math.vector.Vector3i;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
@@ -70,6 +71,15 @@ public class MapSettingsSerializer implements JsonSerializer<BmMap> {
         Vector2i startPos = Optional.ofNullable(map.getMapSettings().getStartPos())
                 .orElse(map.getWorld().getSpawnPoint().toVector2(true));
         root.add("startPos", context.serialize(startPos));
+
+        // bounds
+        JsonObject bounds = new JsonObject();
+        Vector3i min = map.getMapSettings().getMinPos();
+        Vector3i max = map.getMapSettings().getMaxPos();
+        bounds.add("x", context.serialize(new int[] { min.getX(), max.getX() }));
+        bounds.add("y", context.serialize(new int[] { min.getY(), max.getY() }));
+        bounds.add("z", context.serialize(new int[] { min.getZ(), max.getZ() }));
+        root.add("bounds", bounds);
 
         // skyColor
         Color skyColor = new Color().parse(map.getMapSettings().getSkyColor());


### PR DESCRIPTION
### Issue
If there are multiple maps, the player shows up on the lowest priority map of the same dimension but not where the rendered part of chunks are.

### Use case
A nether map with roof transparency and then another map that is only the roof and above (to showcase redstone builds, etc).

- Clicking on a player on a different map, will take the user to the correct map for viewing what they are working on