### PR TITLE
Make render interval slightly more configurable

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/config/CoreConfig.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/CoreConfig.java
@@ -36,6 +36,9 @@ public class CoreConfig {
 
     private int renderThreadCount = 1;
 
+    private int updateRegionAfterInactivity = 5;
+    private int updateRegionMaxInactivityWait = 60;
+
     private boolean metrics = true;
 
     private Path data = Path.of("bluemap");
@@ -55,6 +58,14 @@ public class CoreConfig {
     public int resolveRenderThreadCount() {
         if (renderThreadCount > 0) return renderThreadCount;
         return Math.max(Runtime.getRuntime().availableProcessors() + renderThreadCount, 1);
+    }
+
+    public int getUpdateRegionAfterInactivity() {
+        return updateRegionAfterInactivity;
+    }
+
+    public int getUpdateRegionMaxInactivityWait() {
+        return updateRegionMaxInactivityWait;
     }
 
     public boolean isMetrics() {

--- a/common/src/main/java/de/bluecolored/bluemap/common/plugin/Plugin.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/plugin/Plugin.java
@@ -565,7 +565,7 @@ public class Plugin implements ServerEventListener {
         stopWatchingMap(map);
 
         try {
-            MapUpdateService watcher = new MapUpdateService(renderManager, map);
+            MapUpdateService watcher = new MapUpdateService(blueMap.getConfig(), renderManager, map);
             watcher.start();
             mapUpdateServices.put(map.getId(), watcher);
         } catch (IOException ex) {

--- a/common/src/main/resources/de/bluecolored/bluemap/config/core.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/core.conf
@@ -23,6 +23,11 @@ data: "${data}"
 # Default is 1
 render-thread-count: ${render-thread-count}
 
+# Wait for a region to be inactive for this many seconds before rerendering.
+update-region-after-inactivity: 5
+# Max time to wait for region inactivity (in seconds) before proceeding anyways.
+update-region-max-inactivity-wait: 60
+
 # Controls whether BlueMap should try to find and load mod-resources and datapacks from the server/world-directories.
 # Default is true
 scan-for-mod-resources: true

--- a/implementations/cli/src/main/java/de/bluecolored/bluemap/cli/BlueMapCLI.java
+++ b/implementations/cli/src/main/java/de/bluecolored/bluemap/cli/BlueMapCLI.java
@@ -103,7 +103,7 @@ public class BlueMapCLI {
         if (watch) {
             for (BmMap map : maps.values()) {
                 try {
-                    MapUpdateService watcher = new MapUpdateService(renderManager, map);
+                    MapUpdateService watcher = new MapUpdateService(blueMap.getConfig(), renderManager, map);
                     watcher.start();
                     mapUpdateServices.add(watcher);
                 } catch (IOException ex) {


### PR DESCRIPTION
It seems that at some point, autosave was changed to be a lot more frequent. According to C2ME:
```toml
[generalOptimizations.autoSave]
        # (Default: ENHANCED) Defines how auto save should be handled  
        # VANILLA: Use vanilla auto-save behavior (auto-save performed every tick during ticking)  
        # ENHANCED: Use C2ME enhanced auto-save (auto-save performed when the server have spare time after ticking)  
        # PERIODIC: Use pre-1.18 vanilla auto-save behavior (auto-save performed every 6000 ticks during ticking)  
        #  
        # Please preserve quotes so this config don't break
        # 
        mode = "default"
```

As a result, by default, it seems that BlueMap will rerender chunks every 5 to 10 seconds. This is currently not configurable. This is useful when the user wants changes to be reflected almost immediately; otherwise, the server effectively wastes cycles rendering chunks that nobody will see, only to render them again 10 seconds later.

This PR adds two configuration options:

- `update-region-after-inactivity`: Wait for approximately this many seconds of inactivity on the region file before rerendering it.
- `update-region-max-inactivity-wait`: Approximate max amount of time to wait before rerendering the region anyways.

Setting these to higher values will slow down rendering. This should help on both Vanilla and C2ME servers.