### PR TITLE
Change directional lighting condition to allow more models to be shaded

### DIFF
--- a/common/webapp/src/js/map/hires/HiresVertexShader.js
+++ b/common/webapp/src/js/map/hires/HiresVertexShader.js
@@ -58,7 +58,7 @@ void main() {
     vBlocklight = blocklight;
 
     // apply directional lighting
-    if (vNormal.x * vNormal.z == 0.0) {
+    if (vNormal.y != 0.0 || abs(abs(vNormal.x) - abs(vNormal.z)) != 0.0) {
         float distFac = smoothstep(1000.0, 50.0, distance);
         vAo *= 1.0 - abs(dot(vNormal.xz, lightDirection)) * 0.4 * distFac;
         vAo *= 1.0 - max(0.0, -vNormal.y) * 0.6 * distFac;


### PR DESCRIPTION
Makes the hacky way to exclude grass from directional lighting more specific