### PR TITLE
Support nullable `Throwable`s in the Logger

### DIFF
--- a/core/src/main/java/de/bluecolored/bluemap/core/logger/JavaLogger.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/logger/JavaLogger.java
@@ -24,6 +24,8 @@
  */
 package de.bluecolored.bluemap.core.logger;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -37,7 +39,7 @@ public class JavaLogger extends AbstractLogger {
     }
 
     @Override
-    public void logError(String message, Throwable throwable) {
+    public void logError(String message, @Nullable Throwable throwable) {
         out.log(Level.SEVERE, message, throwable);
     }
 

--- a/core/src/main/java/de/bluecolored/bluemap/core/logger/Logger.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/logger/Logger.java
@@ -24,6 +24,7 @@
  */
 package de.bluecolored.bluemap.core.logger;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -45,11 +46,11 @@ public abstract class Logger implements AutoCloseable {
         }));
     }
 
-    public void logError(Throwable throwable) {
+    public void logError(@NotNull Throwable throwable) {
         logError(throwable.getMessage(), throwable);
     }
 
-    public abstract void logError(String message, Throwable throwable);
+    public abstract void logError(String message, @Nullable Throwable throwable);
 
     public abstract void logWarning(String message);
 
@@ -60,7 +61,7 @@ public abstract class Logger implements AutoCloseable {
     /**
      * Only log the error if no message has been logged before with the same key.
      */
-    public abstract void noFloodError(String key, String message, Throwable throwable);
+    public abstract void noFloodError(String key, String message, @Nullable Throwable throwable);
 
     /**
      * Only log the warning if no message has been logged before with the same key.
@@ -80,14 +81,14 @@ public abstract class Logger implements AutoCloseable {
     /**
      * Only log the error if no message has been logged before with the same content.
      */
-    public void noFloodError(Throwable throwable){
+    public void noFloodError(@NotNull Throwable throwable){
         noFloodError(throwable.getMessage(), throwable);
     }
 
     /**
      * Only log the error if no message has been logged before with the same content.
      */
-    public void noFloodError(String message, Throwable throwable){
+    public void noFloodError(String message, @Nullable Throwable throwable){
         noFloodError(message, message, throwable);
     }
 

--- a/core/src/main/java/de/bluecolored/bluemap/core/logger/MultiLogger.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/logger/MultiLogger.java
@@ -24,6 +24,8 @@
  */
 package de.bluecolored.bluemap.core.logger;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -83,7 +85,7 @@ public class MultiLogger extends AbstractLogger {
     }
 
     @Override
-    public void logError(String message, Throwable throwable) {
+    public void logError(String message, @Nullable Throwable throwable) {
         lock.readLock().lock();
         try {
             for (Logger l : logger.values())

--- a/core/src/main/java/de/bluecolored/bluemap/core/logger/PrintStreamLogger.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/logger/PrintStreamLogger.java
@@ -24,6 +24,8 @@
  */
 package de.bluecolored.bluemap.core.logger;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.PrintStream;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -56,9 +58,9 @@ public class PrintStreamLogger extends AbstractLogger {
     }
 
     @Override
-    public void logError(String message, Throwable throwable) {
+    public void logError(String message, @Nullable Throwable throwable) {
         log(err, "ERROR", message);
-        throwable.printStackTrace(err);
+        if (throwable != null) throwable.printStackTrace(err);
     }
 
     @Override

--- a/core/src/main/java/de/bluecolored/bluemap/core/logger/VoidLogger.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/logger/VoidLogger.java
@@ -24,10 +24,12 @@
  */
 package de.bluecolored.bluemap.core.logger;
 
+import org.jetbrains.annotations.Nullable;
+
 public class VoidLogger extends Logger {
 
     @Override
-    public void logError(String message, Throwable throwable) {}
+    public void logError(String message, @Nullable Throwable throwable) {}
 
     @Override
     public void logWarning(String message) {}
@@ -39,7 +41,7 @@ public class VoidLogger extends Logger {
     public void logDebug(String message) {}
 
     @Override
-    public void noFloodError(String key, String message, Throwable throwable) {}
+    public void noFloodError(String key, String message, @Nullable Throwable throwable) {}
 
     @Override
     public void noFloodWarning(String key, String message) {}

--- a/implementations/fabric/src/main/java/de/bluecolored/bluemap/fabric/Log4jLogger.java
+++ b/implementations/fabric/src/main/java/de/bluecolored/bluemap/fabric/Log4jLogger.java
@@ -27,6 +27,7 @@ package de.bluecolored.bluemap.fabric;
 import org.apache.logging.log4j.Logger;
 
 import de.bluecolored.bluemap.core.logger.AbstractLogger;
+import org.jetbrains.annotations.Nullable;
 
 public class Log4jLogger extends AbstractLogger {
 
@@ -37,7 +38,7 @@ public class Log4jLogger extends AbstractLogger {
     }
 
     @Override
-    public void logError(String message, Throwable throwable) {
+    public void logError(String message, @Nullable Throwable throwable) {
         out.error(message, throwable);
     }
 

--- a/implementations/forge/src/main/java/de/bluecolored/bluemap/forge/Log4jLogger.java
+++ b/implementations/forge/src/main/java/de/bluecolored/bluemap/forge/Log4jLogger.java
@@ -27,6 +27,7 @@ package de.bluecolored.bluemap.forge;
 import org.apache.logging.log4j.Logger;
 
 import de.bluecolored.bluemap.core.logger.AbstractLogger;
+import org.jetbrains.annotations.Nullable;
 
 public class Log4jLogger extends AbstractLogger {
 
@@ -37,7 +38,7 @@ public class Log4jLogger extends AbstractLogger {
     }
 
     @Override
-    public void logError(String message, Throwable throwable) {
+    public void logError(String message, @Nullable Throwable throwable) {
         out.error(message, throwable);
     }
 

--- a/implementations/neoforge/src/main/java/de/bluecolored/bluemap/forge/Log4jLogger.java
+++ b/implementations/neoforge/src/main/java/de/bluecolored/bluemap/forge/Log4jLogger.java
@@ -26,6 +26,7 @@ package de.bluecolored.bluemap.forge;
 
 import de.bluecolored.bluemap.core.logger.AbstractLogger;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 
 public class Log4jLogger extends AbstractLogger {
 
@@ -36,7 +37,7 @@ public class Log4jLogger extends AbstractLogger {
     }
 
     @Override
-    public void logError(String message, Throwable throwable) {
+    public void logError(String message, @Nullable Throwable throwable) {
         out.error(message, throwable);
     }
 

--- a/implementations/sponge/build.gradle.kts
+++ b/implementations/sponge/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     }
 
     api ( libs.bstats.sponge )
+
+    compileOnly ( libs.jetbrains.annotations )
 }
 
 sponge {

--- a/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/Log4J2Logger.java
+++ b/implementations/sponge/src/main/java/de/bluecolored/bluemap/sponge/Log4J2Logger.java
@@ -26,6 +26,7 @@ package de.bluecolored.bluemap.sponge;
 
 import de.bluecolored.bluemap.core.logger.AbstractLogger;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 
 public class Log4J2Logger extends AbstractLogger {
 
@@ -36,7 +37,7 @@ public class Log4J2Logger extends AbstractLogger {
     }
 
     @Override
-    public void logError(String message, Throwable throwable) {
+    public void logError(String message, @Nullable Throwable throwable) {
         out.error(message, throwable);
     }
 


### PR DESCRIPTION
For if you just want to log an error message without a stacktrace


<details>
<summary>Tested on the CLI</summary>

Before:
<img width="1498" height="1006" alt="image" src="https://github.com/user-attachments/assets/a336956b-e3f5-41bb-bcc2-8fd453ced5fd" />

After:
<img width="1218" height="686" alt="image" src="https://github.com/user-attachments/assets/e040385d-6bc8-4827-99a1-ca83b4ad3710" />

</details>


<details>
<summary>Tested on Fabric</summary>

Before:
<img width="1712" height="1348" alt="image" src="https://github.com/user-attachments/assets/d9ed8272-216e-4161-81d2-41208a815c06" />

After:
<img width="1733" height="1281" alt="image" src="https://github.com/user-attachments/assets/bffc7070-81b5-45a1-aeec-668f5d21da79" />

(It already worked, and it now _still_ works)

</details>


<details>
<summary>Tested on Forge</summary>

Before:
<img width="2024" height="995" alt="image" src="https://github.com/user-attachments/assets/8903d145-9ee3-4a86-967b-240573aba6d4" />

After:
<img width="2019" height="1090" alt="image" src="https://github.com/user-attachments/assets/c78c0591-e073-4453-8ae8-c1763676a8a6" />

(It already worked, and it now _still_ works)

</details>


<details>
<summary>Tested on NeoForge</summary>

Before:
<img width="2424" height="1361" alt="image" src="https://github.com/user-attachments/assets/b745d734-8b79-4e59-bdb7-f301f1636de3" />

After:
<img width="2460" height="1365" alt="image" src="https://github.com/user-attachments/assets/4cd3aa66-0733-47c4-b523-2a3481740734" />

(It already worked, and it now _still_ works)

</details>


<details>
<summary>Tested on Paper</summary>

Before:
<img width="1511" height="1366" alt="image" src="https://github.com/user-attachments/assets/83805681-8bb6-446d-a159-acee374765c0" />

After:
<img width="1520" height="1412" alt="image" src="https://github.com/user-attachments/assets/9decec15-baf1-4f6b-b5c7-fdc7f6ef96af" />

(It already worked, and it now _still_ works)

</details>


<details>
<summary>Tested on Spigot</summary>

Before:
<img width="1984" height="2450" alt="image" src="https://github.com/user-attachments/assets/3bc508ac-e753-42bb-82a3-7c99e65804a6" />

After:
<img width="2020" height="2480" alt="image" src="https://github.com/user-attachments/assets/4a3bb74b-d6cc-4c4d-922a-7bfbceac16d5" />

(It already worked, and it now _still_ works)

</details>


<details>
<summary>Tested on Sponge</summary>

(Ignore the unrelated error, please)

Before:
<img width="2542" height="1485" alt="image" src="https://github.com/user-attachments/assets/6c53b806-bfdc-4423-8156-cef6d86db118" />

After:
<img width="2545" height="1493" alt="image" src="https://github.com/user-attachments/assets/f35c235a-9161-422c-a641-4fe143926dcc" />

(It already worked, and it now _still_ works)

</details>