### PR TITLE
Fix inheritance of ambientocclusion property from parent model

### DIFF
--- a/core/src/main/java/de/bluecolored/bluemap/core/resources/pack/resourcepack/model/Model.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/resources/pack/resourcepack/model/Model.java
@@ -44,7 +44,7 @@ public class Model {
     private @Nullable ResourcePath<Model> parent;
     private Map<String, TextureVariable> textures = new HashMap<>();
     private Element @Nullable [] elements;
-    private boolean ambientocclusion = true;
+    @Getter(AccessLevel.NONE) private Boolean ambientocclusion;
 
     private transient boolean culling = false;
     private transient boolean occluding = false;
@@ -101,6 +101,10 @@ public class Model {
         if (parent != null) {
             parent.applyParent(modelPool);
 
+            if (this.ambientocclusion == null && parent.ambientocclusion != null) {
+                this.ambientocclusion = parent.ambientocclusion;
+            }
+
             parent.textures.forEach(this::applyTextureVariable);
             if (this.elements == null && parent.elements != null) {
                 this.elements = new Element[parent.elements.length];
@@ -148,6 +152,11 @@ public class Model {
                 break;
             }
         }
+    }
+
+    public boolean isAmbientocclusion() {
+        if (ambientocclusion == null) return true;
+        return ambientocclusion;
     }
 
 }


### PR DESCRIPTION
I only noticed this bug because I encountered a similar bug (with a more noticeable property) in BlueMapModelLoaders.

A simple test with the following resource pack:

assets/minecraft/models/block/pink_wool.json :
``` 
{
  "parent": "minecraft:block/cube_all",
  "ambientocclusion": "false",
  "textures": {
    "all": "minecraft:block/pink_wool"
  }
}
```
assets/minecraft/models/block/white_wool.json :
```
{
  "parent": "minecraft:block/pink_wool",
  "textures": {
    "all": "minecraft:block/white_wool"
  }
}
```
assets/minecraft/models/block/light_gray_wool.json :
```
{
  "parent": "minecraft:block/pink_wool",
  "ambientocclusion": "true",
  "textures": {
    "all": "minecraft:block/light_gray_wool"
  }
}
``` 
Before:
<img width="807" height="241" alt="image" src="https://github.com/user-attachments/assets/bb2c2d60-7d3d-4c34-80bf-6d0b70a21f15" />
After:
<img width="800" height="241" alt="image" src="https://github.com/user-attachments/assets/cab1497b-2cfd-453f-9c6b-335f7522a027" />
