### PR TITLE
Fix incorrect onPlayerLeave handling in EventForwarder.java inside PaperMC

### DIFF
--- a/implementations/paper/src/main/java/de/bluecolored/bluemap/bukkit/EventForwarder.java
+++ b/implementations/paper/src/main/java/de/bluecolored/bluemap/bukkit/EventForwarder.java
@@ -57,7 +57,7 @@ public class EventForwarder implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public synchronized void onPlayerLeave(PlayerQuitEvent evt) {
-        for (ServerEventListener listener : listeners) listener.onPlayerJoin(evt.getPlayer().getUniqueId());
+        for (ServerEventListener listener : listeners) listener.onPlayerLeave(evt.getPlayer().getUniqueId());
     }
 
 }


### PR DESCRIPTION
Hi everyone, not really sure if this is a bug or intended, just found it while reading the code.