### PR TITLE
Switch to webserver using a virtual-thread per connection

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/web/BlueMapResponseModifier.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/BlueMapResponseModifier.java
@@ -49,8 +49,8 @@ public class BlueMapResponseModifier implements HttpRequestHandler {
         HttpResponse response = delegate.handle(request);
 
         HttpStatusCode status = response.getStatusCode();
-        if (status.getCode() >= 400 && !response.hasData()){
-            response.setData(status.getCode() + " - " + status.getMessage() + "\n" + this.serverName);
+        if (status.getCode() >= 400 && response.getBody() != null){
+            response.setBody(status.getCode() + " - " + status.getMessage() + "\n" + this.serverName);
         }
 
         response.addHeader("Server", this.serverName);

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/FileRequestHandler.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/FileRequestHandler.java
@@ -85,7 +85,7 @@ public class FileRequestHandler implements HttpRequestHandler {
         // redirect to have correct relative paths
         if (Files.isDirectory(filePath) && !request.getPath().endsWith("/")) {
             HttpResponse response = new HttpResponse(HttpStatusCode.SEE_OTHER);
-            response.addHeader("Location", "/" + path + "/" + (request.getGETParamString().isEmpty() ? "" : "?" + request.getGETParamString()));
+            response.addHeader("Location", "/" + path + "/" + (request.getRawQueryString().isEmpty() ? "" : "?" + request.getRawQueryString()));
             return response;
         }
 
@@ -151,7 +151,7 @@ public class FileRequestHandler implements HttpRequestHandler {
 
         //send response
         try {
-            response.setData(Files.newInputStream(filePath));
+            response.setBody(Files.newInputStream(filePath));
             return response;
         } catch (FileNotFoundException e) {
             return new HttpResponse(HttpStatusCode.NOT_FOUND);

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/JsonDataRequestHandler.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/JsonDataRequestHandler.java
@@ -48,7 +48,7 @@ public class JsonDataRequestHandler implements HttpRequestHandler {
         HttpResponse response = new HttpResponse(HttpStatusCode.OK);
         response.addHeader("Cache-Control", "no-cache");
         response.addHeader("Content-Type", "application/json");
-        response.setData(dataSupplier.get());
+        response.setBody(dataSupplier.get());
         return response;
     }
 

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/LoggingRequestHandler.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/LoggingRequestHandler.java
@@ -31,8 +31,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 
-import java.net.URI;
-
 @Getter @Setter
 @AllArgsConstructor
 public class LoggingRequestHandler implements HttpRequestHandler {
@@ -65,7 +63,9 @@ public class LoggingRequestHandler implements HttpRequestHandler {
         }
 
         String method = request.getMethod();
-        URI address = request.getAddress();
+        String path = request.getPath();
+        String queryString = request.getRawQueryString();
+        String address = queryString == null ? path : path + "?" + queryString;
         String version = request.getVersion();
 
         // run request
@@ -81,7 +81,7 @@ public class LoggingRequestHandler implements HttpRequestHandler {
                 source,
                 xffSource,
                 method,
-                address.toString(),
+                address,
                 version,
                 statusCode,
                 statusMessage

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/MapStorageRequestHandler.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/MapStorageRequestHandler.java
@@ -122,7 +122,7 @@ public class MapStorageRequestHandler implements HttpRequestHandler {
                 request.hasHeaderValue("Accept-Encoding", compression.getId())
         ) {
             response.addHeader("Content-Encoding", compression.getId());
-            response.setData(data);
+            response.setBody(data);
         } else if (
                 compression != Compression.GZIP &&
                 !response.hasHeaderValue("Content-Type", "image/png") &&
@@ -134,9 +134,9 @@ public class MapStorageRequestHandler implements HttpRequestHandler {
                 data.decompress().transferTo(os);
             }
             byte[] compressedData = byteOut.toByteArray();
-            response.setData(new ByteArrayInputStream(compressedData));
+            response.setBody(new ByteArrayInputStream(compressedData));
         } else {
-            response.setData(data.decompress());
+            response.setBody(data.decompress());
         }
     }
 

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpHeaderCarrier.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpHeaderCarrier.java
@@ -24,7 +24,25 @@
  */
 package de.bluecolored.bluemap.common.web.http;
 
-import java.nio.channels.SelectionKey;
-import java.util.function.Consumer;
+import java.util.Locale;
+import java.util.Map;
 
-public interface SelectionConsumer extends Consumer<SelectionKey> {}
+public interface HttpHeaderCarrier {
+
+    Map<String, HttpHeader> getHeaders();
+
+    default void addHeader(String name, String... values) {
+        getHeaders().put(name.toLowerCase(Locale.ROOT), new HttpHeader(name, values));
+    }
+
+    default HttpHeader getHeader(String key) {
+        return getHeaders().get(key.toLowerCase(Locale.ROOT));
+    }
+
+    default boolean hasHeaderValue(String key, String value) {
+        HttpHeader header = getHeader(key);
+        if (header == null) return false;
+        return header.contains(value);
+    }
+
+}

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpRequest.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpRequest.java
@@ -24,262 +24,60 @@
  */
 package de.bluecolored.bluemap.common.web.http;
 
+import lombok.*;
+import org.jetbrains.annotations.Nullable;
+
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-public class HttpRequest {
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class HttpRequest implements HttpHeaderCarrier {
 
-    private static final Pattern REQUEST_PATTERN = Pattern.compile("^(\\w+) (\\S+) (.+)$");
+    private @NonNull InetAddress source;
+    private @NonNull String method;
+    private @NonNull String path;
+    private @NonNull @Singular Map<String, String> queryParams = new LinkedHashMap<>();
+    private @NonNull String version = "HTTP/1.1";
+    private @NonNull @Singular Map<String, HttpHeader> headers = new LinkedHashMap<>();
+    private byte @NonNull [] body = new byte[0];
 
-    // reading helper
-    private final ByteBuffer byteBuffer = ByteBuffer.allocate(1024);
-    private final StringBuffer lineBuffer = new StringBuffer();
-
-    private boolean complete = false;
-    private boolean headerComplete = false;
-    private final List<String> headerLines = new ArrayList<>(20);
-
-    // request data
-    private final InetAddress source;
-    private URI address;
-    private String method, version;
-    private final Map<String, HttpHeader> headers = new HashMap<>();
-    private byte[] data;
-
-    // these values can be overwritten separately by a HttpRequestHandler for delegation
-    private String path = null;
-    private String getParamString = null;
-    private Map<String, String> getParams = null;
-
-    public HttpRequest(InetAddress source) {
-        this.source = source;
+    public String getQueryParam(String key) {
+        return queryParams.get(key);
     }
 
-    public boolean write(ReadableByteChannel channel) throws IOException {
-        if (complete) return true;
+    public String getRawQueryString() {
+        return queryParams.entrySet().stream()
+                .map(e -> e.getValue().isEmpty() ? e.getKey() :
+                        URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8)
+                                + "="
+                                + URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8)
+                )
+                .collect(Collectors.joining("&"));
+    }
 
-        int read = channel.read(byteBuffer);
-        if (read == 0) return false;
-        if (read == -1) {
-            channel.close();
-            return false;
-        }
-
-        byteBuffer.flip();
-        try {
-
-            // read headers
-            while (!headerComplete) {
-                if (!writeLine()) return false;
-                String line = lineBuffer.toString().stripTrailing();
-                lineBuffer.setLength(0);
-
-                if (line.isEmpty()) {
-                    headerComplete = true;
-                    parseHeaders();
-                } else {
-                    headerLines.add(line);
-                }
-            }
-
-            if (hasHeaderValue("transfer-encoding", "chunked")) {
-                writeChunkedBody();
-            } else {
-                HttpHeader contentLengthHeader = getHeader("content-length");
-                int contentLength = 0;
-                if (contentLengthHeader != null) {
-                    try {
-                        contentLength = Integer.parseInt(contentLengthHeader.getValue().trim());
-                    } catch (NumberFormatException ex) {
-                        throw new IOException("Invalid HTTP Request: content-length is not a number", ex);
-                    }
-                }
-
-                if (contentLength > 0) {
-                    writeBody(contentLength);
-                }
-            }
-
-            complete = true;
-            return true;
-
-        } finally {
-            byteBuffer.compact();
+    public void setRawQueryString(@Nullable String rawQueryString) {
+        queryParams.clear();
+        if (rawQueryString == null) return;
+        for (String param : rawQueryString.split("&")){
+            if (param.isEmpty()) continue;
+            String[] kv = param.split("=", 2);
+            String key = URLDecoder.decode(kv[0], StandardCharsets.UTF_8);
+            String value = kv.length > 1 ? URLDecoder.decode(kv[1], StandardCharsets.UTF_8) : "";
+            queryParams.put(key, value);
         }
     }
 
-    private void writeChunkedBody() {
-        // TODO
-    }
-
-    private void writeBody(int length) {
-        // TODO
-    }
-
-    private void parseHeaders() throws IOException {
-        if (headerLines.isEmpty()) throw new IOException("Invalid HTTP Request: No Header");
-
-        Matcher m = REQUEST_PATTERN.matcher(headerLines.get(0));
-        if (!m.find()) throw new IOException("Invalid HTTP Request: Request-Pattern not matching");
-
-        method = m.group(1);
-        if (method == null) throw new IOException("Invalid HTTP Request: Request-Pattern not matching (method)");
-
-        String addressString = m.group(2);
-        if (addressString == null) throw new IOException("Invalid HTTP Request: Request-Pattern not matching (address)");
-        try {
-            address = new URI(addressString);
-        } catch (URISyntaxException ex) {
-            throw new IOException("Invalid HTTP Request: Request-URI is invalid", ex);
-        }
-
-        version = m.group(3);
-        if (version == null) throw new IOException("Invalid HTTP Request: Request-Pattern not matching (version)");
-
-        headers.clear();
-        for (int i = 1; i < headerLines.size(); i++) {
-            String line = headerLines.get(i);
-            if (line.trim().isEmpty()) continue;
-
-            String[] kv = line.split(":", 2);
-            if (kv.length < 2) continue;
-
-            headers.put(kv[0].trim().toLowerCase(Locale.ROOT), new HttpHeader(kv[0], kv[1]));
-        }
-    }
-
-    private boolean writeLine() {
-        while (lineBuffer.length() <= 0 || lineBuffer.charAt(lineBuffer.length() - 1) != '\n'){
-            if (!byteBuffer.hasRemaining()) return false;
-            lineBuffer.append((char) byteBuffer.get());
-        }
-        return true;
-    }
-
-    public InetAddress getSource() {
-        return source;
-    }
-
-    public String getMethod() {
-        return method;
-    }
-
-    public void setMethod(String method) {
-        this.method = method;
-    }
-
-    public URI getAddress() {
-        return address;
-    }
-
-    public void setAddress(URI address) {
-        this.address = address;
-        this.path = null;
-        this.getParams = null;
-        this.getParamString = null;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public Map<String, HttpHeader> getHeaders() {
-        return headers;
-    }
-
-    public HttpHeader getHeader(String header) {
-        return this.headers.get(header.toLowerCase(Locale.ROOT));
-    }
-
-    public boolean hasHeaderValue(String key, String value) {
-        HttpHeader header = getHeader(key);
-        if (header == null) return false;
-        return header.contains(value);
-    }
-
-    public byte[] getData() {
-        return data;
-    }
-
-    public InputStream getDataStream() {
-        return new ByteArrayInputStream(data);
-    }
-
-    public String getPath() {
-        if (path == null) parseAddress();
-        return path;
-    }
-
-    public void setPath(String path) {
-        this.path = path;
-    }
-
-    public Map<String, String> getGETParams() {
-        if (getParams == null) parseGetParams();
-        return getParams;
-    }
-
-    public String getGETParamString() {
-        if (getParamString == null) parseAddress();
-        return getParamString;
-    }
-
-    public void setGetParamString(String getParamString) {
-        this.getParamString = getParamString;
-        this.getParams = null;
-    }
-
-    private void parseAddress() {
-        this.path = address.getPath();
-        this.getParamString = address.getQuery();
-    }
-
-    private void parseGetParams() {
-        Map<String, String> getParams = new HashMap<>();
-        for (String getParam : this.getGETParamString().split("&")){
-            if (getParam.isEmpty()) continue;
-            String[] kv = getParam.split("=", 2);
-            String key = kv[0];
-            String value = kv.length > 1 ? kv[1] : "";
-            getParams.put(key, value);
-        }
-        this.getParams = getParams;
-    }
-
-    public boolean isComplete() {
-        return complete;
-    }
-
-    public void clear() {
-        byteBuffer.clear();
-        lineBuffer.setLength(0);
-
-        complete = false;
-        headerComplete = false;
-        headerLines.clear();
-
-        method = null;
-        address = null;
-        version = null;
-        headers.clear();
-        data = null;
-
-        path = null;
-        getParamString = null;
-        getParams = null;
+    public InputStream getBodyStream() {
+        return new ByteArrayInputStream(body);
     }
 
 }

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpRequestInputStream.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpRequestInputStream.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of BlueMap, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Blue (Lukas Rieger) <https://bluecolored.de>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package de.bluecolored.bluemap.common.web.http;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.net.InetAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRequestInputStream implements Closeable {
+
+    private static final Pattern REQUEST_PATTERN = Pattern.compile("^(\\w+) (\\S+) (.+)$");
+
+    private final InetAddress source;
+    private final DataInputStream in;
+    private final Reader reader;
+
+    private byte[] byteBuffer = new byte[1024];
+    private final char[] charBuffer = new char[1];
+
+    public HttpRequestInputStream(InputStream in, InetAddress source) {
+        this.source = source;
+        this.in = new DataInputStream(in);
+        this.reader = new InputStreamReader(this.in, StandardCharsets.UTF_8);
+    }
+
+    public @Nullable HttpRequest read() throws IOException {
+
+        String requestLine;
+        requestLine = readLine();
+
+        Matcher m = REQUEST_PATTERN.matcher(requestLine);
+        if (!m.find()) throw new IOException("Invalid HTTP Request: Request-Pattern not matching '%s'".formatted(requestLine));
+
+        URI address = URI.create(m.group(2));
+
+        HttpRequest request = new HttpRequest(
+                source,
+                m.group(1),
+                address.getPath()
+        );
+        request.setVersion(m.group(3));
+        request.setRawQueryString(address.getRawQuery());
+
+        // headers
+        while (true) {
+            String line = readLine();
+            if (line.isBlank()) break;
+
+            String[] kv = line.split(":", 2);
+            if (kv.length < 2) continue;
+
+            request.addHeader(kv[0], kv[1].trim());
+        }
+
+        // body
+        if (request.hasHeaderValue("transfer-encoding", "chunked")) {
+            request.setBody(readChunkedBody());
+        } else {
+            HttpHeader contentLengthHeader = request.getHeader("content-length");
+            int contentLength = 0;
+            if (contentLengthHeader != null) {
+                try {
+                    contentLength = Integer.parseInt(contentLengthHeader.getValue().trim());
+                } catch (NumberFormatException ex) {
+                    throw new IOException("Invalid HTTP Request: content-length is not a number", ex);
+                }
+            }
+
+            if (contentLength > 0) {
+                request.setBody(readBody(contentLength));
+            }
+        }
+
+        return request;
+    }
+
+    private String readLine() throws IOException {
+
+        StringBuilder stringBuilder = new StringBuilder();
+        do {
+            if (reader.read(charBuffer, 0, 1) == -1) throw new EOFException();
+            stringBuilder.append(charBuffer, 0, 1);
+        } while (charBuffer[0] != '\n');
+
+        return stringBuilder.toString();
+    }
+
+    private byte[] readChunkedBody() throws IOException {
+        ByteArrayOutputStream body = new ByteArrayOutputStream(1024);
+
+        while (true) {
+            String prefix = readLine();
+            int size = Integer.valueOf(prefix.formatted(), 16);
+            if (size > byteBuffer.length) byteBuffer = new byte[size];
+            size = in.readNBytes(byteBuffer, 0, size);
+            body.write(byteBuffer, 0, size);
+            readLine(); // suffix
+            if (size == 0) break;
+        }
+
+        return body.toByteArray();
+    }
+
+    private byte[] readBody(int contentLength) throws IOException {
+        return in.readNBytes(contentLength);
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+}

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpResponse.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpResponse.java
@@ -24,187 +24,49 @@
  */
 package de.bluecolored.bluemap.common.web.http;
 
+import lombok.*;
+import org.jetbrains.annotations.Nullable;
+
 import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Locale;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class HttpResponse implements Closeable {
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class HttpResponse implements Closeable, HttpHeaderCarrier {
 
-    private static final byte[] CHUNK_SUFFIX = "\r\n".getBytes(StandardCharsets.UTF_8);
+    private @NonNull String version = "HTTP/1.1";
+    private @NonNull HttpStatusCode statusCode;
+    private @NonNull @Singular Map<String, HttpHeader> headers = new LinkedHashMap<>();
+    private @Nullable InputStream body;
 
-    private String version;
-    private HttpStatusCode statusCode;
-    private final Map<String, HttpHeader> headers;
-    private ReadableByteChannel data;
-
-    private ByteBuffer headerData;
-    private ByteBuffer dataBuffer;
-    private boolean complete = false;
-    private boolean headerComplete = false;
-    private boolean dataChannelComplete = false;
-    private boolean dataComplete = false;
-
-    public HttpResponse(HttpStatusCode statusCode) {
-        this.version = "HTTP/1.1";
-        this.statusCode = statusCode;
-
-        this.headers = new HashMap<>();
+    public void setBody(@Nullable InputStream body) {
+        this.body = body;
     }
 
-    public synchronized boolean read(WritableByteChannel channel) throws IOException {
-        if (complete) return true;
-
-        // send headers
-        if (!headerComplete) {
-            if (headerData == null) writeHeaderData();
-            if (headerData.hasRemaining()) {
-                channel.write(headerData);
-            }
-
-            if (headerData.hasRemaining()) return false;
-            headerComplete = true;
-            headerData = null; // free ram
+    public void setBody(byte[] data) {
+        if (data == null) {
+            this.body = null;
+            return;
         }
 
-        if (!hasData()){
-            complete = true;
-            return true;
+        setBody(new ByteArrayInputStream(data));
+    }
+
+    public void setBody(String data) {
+        if (data == null) {
+            this.body = null;
+            return;
         }
 
-        // send data chunked
-        if (dataBuffer == null) dataBuffer = ByteBuffer.allocate(1024 + 200).flip(); // 200 extra bytes
-        while (true) {
-            if (dataBuffer.hasRemaining()) channel.write(dataBuffer);
-            if (dataBuffer.hasRemaining()) return false;
-            if (dataComplete) break; // nothing more to do
-
-            // fill data buffer from channel
-            dataBuffer.clear();
-            dataBuffer.position(100); // keep 100 space in front
-            dataBuffer.limit(1124); // keep 100 space at the end
-
-            int readTotal = 0;
-            if (!dataChannelComplete) {
-                int read = 0;
-                while (dataBuffer.hasRemaining() && (read = data.read(dataBuffer)) != -1) {
-                    readTotal += read;
-                }
-
-                if (read == -1) dataChannelComplete = true;
-            }
-
-            if (readTotal == 0) dataComplete = true;
-
-            byte[] chunkPrefix = (Integer.toHexString(readTotal) + "\r\n")
-                    .getBytes(StandardCharsets.UTF_8);
-
-            dataBuffer.limit(dataBuffer.capacity());
-            dataBuffer.put(CHUNK_SUFFIX);
-            dataBuffer.limit(dataBuffer.position());
-
-            int startPos = 100 - chunkPrefix.length;
-            dataBuffer.position(startPos);
-            dataBuffer.put(chunkPrefix);
-            dataBuffer.position(startPos);
-        }
-
-        complete = true;
-        return true;
-    }
-
-    private void writeHeaderData() {
-        ByteArrayOutputStream headerDataOut = new ByteArrayOutputStream();
-
-        if (hasData()){
-            headers.put("Transfer-Encoding", new HttpHeader("Transfer-Encoding", "chunked"));
-        } else {
-            headers.put("Content-Length", new HttpHeader("Content-Length", "0"));
-        }
-
-        headerDataOut.writeBytes((version + " " + statusCode.getCode() + " " + statusCode.getMessage() + "\r\n")
-                .getBytes(StandardCharsets.UTF_8));
-        for (HttpHeader header : headers.values()){
-            headerDataOut.writeBytes((header.getKey() + ": " + header.getValue() + "\r\n")
-                    .getBytes(StandardCharsets.UTF_8));
-        }
-        headerDataOut.writeBytes(("\r\n")
-                .getBytes(StandardCharsets.UTF_8));
-
-        headerData = ByteBuffer.allocate(headerDataOut.size())
-                .put(headerDataOut.toByteArray())
-                .flip();
-    }
-
-    public void addHeader(String key, String value){
-        HttpHeader header;
-        HttpHeader existing = getHeader(key);
-        if (existing != null) {
-            header = new HttpHeader(existing.getKey(), existing.getValue() + ", " + value);
-        } else {
-            header = new HttpHeader(key, value);
-        }
-        this.headers.put(key.toLowerCase(Locale.ROOT), header);
-    }
-
-    public void setData(ReadableByteChannel channel){
-        this.data = channel;
-    }
-
-    public void setData(InputStream dataStream){
-        this.data = Channels.newChannel(dataStream);
-    }
-
-    public void setData(String data){
-        setData(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)));
-    }
-
-    public boolean hasData() {
-        return this.data != null;
-    }
-
-    public boolean isComplete() {
-        return complete;
+        setBody(data.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
     public void close() throws IOException {
-        if (data != null) data.close();
-    }
-
-    public HttpStatusCode getStatusCode(){
-        return statusCode;
-    }
-
-    public void setStatusCode(HttpStatusCode statusCode) {
-        this.statusCode = statusCode;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public Map<String, HttpHeader> getHeaders() {
-        return headers;
-    }
-
-    public HttpHeader getHeader(String header) {
-        return this.headers.get(header.toLowerCase(Locale.ROOT));
-    }
-
-    public boolean hasHeaderValue(String key, String value) {
-        HttpHeader header = getHeader(key);
-        if (header == null) return false;
-        return header.contains(value);
+        if (body != null) body.close();
     }
 
 }

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpResponseOutputStream.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpResponseOutputStream.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of BlueMap, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Blue (Lukas Rieger) <https://bluecolored.de>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package de.bluecolored.bluemap.common.web.http;
+
+import lombok.RequiredArgsConstructor;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+public class HttpResponseOutputStream implements Closeable {
+
+    private static final byte[] CRLF = "\r\n".getBytes(StandardCharsets.UTF_8);
+
+    private final OutputStream outputStream;
+
+    private final byte[] byteBuffer = new byte[1024];
+
+    public void write(HttpResponse response) throws IOException {
+        HttpStatusCode statusCode = response.getStatusCode();
+        InputStream body = response.getBody();
+
+        writeLine(response.getVersion() + " " + statusCode.getCode() + " " + statusCode.getMessage());
+
+        // headers
+        if (body != null) {
+            response.addHeader("Transfer-Encoding","chunked");
+        } else {
+            response.addHeader("Content-Length", "0");
+        }
+        for (HttpHeader header : response.getHeaders().values()) {
+            writeLine(header.getKey() + ": " + header.getValue());
+        }
+        writeLine();
+
+        // body
+        if (body != null) {
+
+            while (true) {
+                int read = body.read(byteBuffer);
+                if (read == -1) break;
+                if (read == 0) continue;
+                writeLine(Integer.toHexString(read));
+                outputStream.write(byteBuffer, 0, read);
+                writeLine();
+            }
+
+            writeLine(Integer.toHexString(0));
+            writeLine();
+        }
+
+        outputStream.flush();
+    }
+
+    private void writeLine() throws IOException {
+        outputStream.write(CRLF);
+    }
+
+    private void writeLine(String line) throws IOException {
+        outputStream.write(line.getBytes(StandardCharsets.UTF_8));
+        outputStream.write(CRLF);
+    }
+
+    @Override
+    public void close() throws IOException {
+        outputStream.close();
+    }
+
+}

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpServer.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/http/HttpServer.java
@@ -28,19 +28,29 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.io.IOException;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class HttpServer extends Server {
 
     @Getter @Setter
     private HttpRequestHandler requestHandler;
+    private ExecutorService executor;
+
+    public HttpServer(HttpRequestHandler requestHandler, ExecutorService executor) throws IOException {
+        this.requestHandler = requestHandler;
+        this.executor = executor;
+    }
 
     public HttpServer(HttpRequestHandler requestHandler) throws IOException {
-        this.requestHandler = requestHandler;
+        this(requestHandler, Executors.newVirtualThreadPerTaskExecutor());
     }
 
     @Override
-    public SelectionConsumer createConnectionHandler() {
-        return new HttpConnection(requestHandler);
+    public void handleConnection(SocketChannel connection) throws IOException {
+        connection.socket().setSoTimeout(600000); // set a 10 min max idle timeout
+        executor.execute(new HttpConnection(connection.socket(), requestHandler));
     }
 
 }


### PR DESCRIPTION
This PR reimplements the webserver for a better to read implemementation using blocking-io but a virtual-thread per connection.

This PR should only be merged once BlueMap depends on Java 24 or higher. In earlier Java versions the virtual-threads can lead to deadlocks when accessing a database due to neccesary `synchronized` blocks in the database connection-pool leading to [thread-pinning](https://docs.oracle.com/en/java/javase/21/core/virtual-threads.html#GUID-704A716D-0662-4BC7-8C7F-66EE74B1EDAD).
Thread-Pinning has been fixed in Java 24.