### PR TITLE
Allow remapping resources via addons

### DIFF
--- a/core/src/main/java/de/bluecolored/bluemap/core/resources/pack/ResourcePool.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/resources/pack/ResourcePool.java
@@ -39,6 +39,18 @@ public class ResourcePool<T> {
 
     private final Map<Key, T> pool = new HashMap<>();
     private final Map<Key, ResourcePath<T>> paths = new HashMap<>();
+    private final ResourcePoolMapper mapper;
+    private final Class<T> type;
+
+    public ResourcePool() {
+        this.type = null;
+        this.mapper = null;
+    }
+
+    public ResourcePool(Class<T> type, ResourcePoolMapper mapper) {
+        this.type = type;
+        this.mapper = mapper;
+    }
 
     public void put(Key path, T value) {
         put(new ResourcePath<>(path), value);
@@ -70,6 +82,9 @@ public class ResourcePool<T> {
     }
 
     public boolean contains(Key path) {
+        if (mapper != null) {
+            path = mapper.remapResource(type, path);
+        }
         return paths.containsKey(path);
     }
 
@@ -78,7 +93,7 @@ public class ResourcePool<T> {
     }
 
     public @Nullable T get(Key path) {
-        ResourcePath<T> rp = paths.get(path);
+        ResourcePath<T> rp = getPath(path);
         return rp == null ? null : rp.getResource(this::get);
     }
 
@@ -88,6 +103,9 @@ public class ResourcePool<T> {
     }
 
     public @Nullable ResourcePath<T> getPath(Key path) {
+        if (mapper != null) {
+            path = mapper.remapResource(type, path);
+        }
         return paths.get(path);
     }
 

--- a/core/src/main/java/de/bluecolored/bluemap/core/resources/pack/ResourcePoolMapper.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/resources/pack/ResourcePoolMapper.java
@@ -1,0 +1,9 @@
+package de.bluecolored.bluemap.core.resources.pack;
+
+import de.bluecolored.bluemap.core.util.Key;
+
+import java.lang.reflect.Type;
+
+public interface ResourcePoolMapper {
+    Key remapResource(Type type, Key src);
+}

--- a/core/src/main/java/de/bluecolored/bluemap/core/resources/pack/resourcepack/ResourcePackExtension.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/resources/pack/resourcepack/ResourcePackExtension.java
@@ -27,6 +27,7 @@ package de.bluecolored.bluemap.core.resources.pack.resourcepack;
 import de.bluecolored.bluemap.core.resources.pack.PackExtension;
 import de.bluecolored.bluemap.core.util.Key;
 
+import java.lang.reflect.Type;
 import java.util.Set;
 
 public interface ResourcePackExtension extends PackExtension {
@@ -35,4 +36,7 @@ public interface ResourcePackExtension extends PackExtension {
         return Set.of();
     }
 
+    default Key remapResource(Type type, Key src) {
+        return src;
+    }
 }


### PR DESCRIPTION
This allows remapping ResourcePool from one key to another via an addon programmatically.

The reasoning behind this is a mod called EveryCompat (or WoodGood): It basically adds "missing" blocks to all types of wood to make sure you can build, say, a bookshelf out of every modded wood type you have.

The issue is, this causes it to generate block state names like `everycompat:q/environmental/azalia_bookshelf` or `everycompat:abnbl/boatload/azalia_boat`.

This allows making an addon for example like https://github.com/Doridian/BlueMapEveryCompatCompat which remaps the resources correctly as seen here: https://github.com/Doridian/BlueMapEveryCompatCompat/blob/main/src/main/java/net/doridian/bluemapeverycompatcompat/EveryCompatResourcePack.java#L27