### PR TITLE
Use npm ci rather than npm install

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -31,6 +31,7 @@ node {
     version = "20.14.0"
     download = true
     nodeProjectDir = file("webapp/")
+    npmInstallCommand = "ci"
 }
 
 tasks.register("buildWebapp", type = NpmTask::class) {


### PR DESCRIPTION
Use `npm ci` when building the webapp with gradle for a deterministic release build.

Also reduces risk of being impacted by supply chain attacks such as the recent [Shai-Hulud 2.0](https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack).