### PR TITLE
Allow browsers to cache files

### DIFF
--- a/common/webapp/.eslintrc.cjs
+++ b/common/webapp/.eslintrc.cjs
@@ -1,6 +1,9 @@
 /* eslint-env node */
 module.exports = {
   root: true,
+  env: {
+    es2022: true
+  },
   'extends': [
     'plugin:vue/vue3-essential',
     'eslint:recommended'

--- a/common/webapp/src/js/markers/MarkerManager.js
+++ b/common/webapp/src/js/markers/MarkerManager.js
@@ -22,9 +22,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import {FileLoader} from "three";
 import {MarkerSet} from "./MarkerSet";
-import {alert, generateCacheHash} from "../util/Utils";
+import {alert} from "../util/Utils";
+import {RevalidatingFileLoader} from "../util/RevalidatingFileLoader";
 
 /**
  * A manager for loading and updating markers from a file
@@ -116,9 +116,10 @@ export class MarkerManager {
      */
     loadMarkerFile() {
         return new Promise((resolve, reject) => {
-            let loader = new FileLoader();
+            let loader = new RevalidatingFileLoader();
+            loader.setRevalidatedUrls(new Set()); // force no-cache requests
             loader.setResponseType("json");
-            loader.load(this.fileUrl + "?" + generateCacheHash(),
+            loader.load(this.fileUrl,
                 markerFileData => {
                     if (!markerFileData) reject(`Failed to parse '${this.fileUrl}'!`);
                     else resolve(markerFileData);

--- a/common/webapp/src/js/util/RevalidatingFileLoader.js
+++ b/common/webapp/src/js/util/RevalidatingFileLoader.js
@@ -1,0 +1,358 @@
+// based on https://github.com/mrdoob/three.js/blob/a58e9ecf225b50e4a28a934442e854878bc2a959/src/loaders/FileLoader.js
+
+import {Loader, Cache} from "three";
+/** @import {LoadingManager} from "three" */
+
+/** @type {Record<string, {revalidatedUrls: Set<string> | undefined, callbacks: Array<{onLoad: function, onProgress: function, onError: function}>>}} */
+const loading = Object.create(null);
+
+const warn = console.warn;
+
+class HttpError extends Error {
+    constructor(message, response) {
+        super(message);
+        this.response = response;
+    }
+}
+
+/**
+ * A FileLoader that, if passed a Set of URLs, will be put into a mode where it
+ * revalidates files by setting the Request cache option to "no-cache" for URLs
+ * that have not previously been revalidated.
+ *
+ * This loader supports caching. If you want to use it, add `THREE.Cache.enabled = true;`
+ * once to your application.
+ *
+ * ```js
+ * const loader = new THREE.FileLoader();
+ * const data = await loader.loadAsync( 'example.txt' );
+ * ```
+ *
+ * @augments Loader
+ */
+export class RevalidatingFileLoader extends Loader {
+    /**
+     * Constructs a new file loader.
+     *
+     * @param {LoadingManager} [manager] - The loading manager.
+     */
+    constructor(manager) {
+        super(manager);
+
+        /**
+         * The expected mime type. Valid values can be found
+         * [here](hhttps://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#mimetype)
+         *
+         * @type {string}
+         */
+        this.mimeType = "";
+
+        /**
+         * The expected response type.
+         *
+         * @type {('arraybuffer'|'blob'|'document'|'json'|'')}
+         * @default ''
+         */
+        this.responseType = "";
+
+        /**
+         * Used for aborting requests.
+         *
+         * @private
+         * @type {AbortController}
+         */
+        this._abortController = new AbortController();
+
+        /**
+         * If set to a Set, this loader will revalidate URLs by setting the
+         * Request cache option to "no-cache" for URLs not in the Set, adding
+         * them to the Set once loaded.
+         *
+         * @type {Set<string> | undefined}
+         */
+        this._revalidatedUrls = undefined;
+    }
+
+    /**
+     * @param {Set<string> | undefined} revalidatedUrls - If set to a Set, this
+     *   loader will revalidate URLs by setting the Request cache option to
+     *   "no-cache" for URLs not in the Set, adding them to the Set once loaded.
+     */
+    setRevalidatedUrls(revalidatedUrls) {
+        this._revalidatedUrls = revalidatedUrls;
+        return this;
+    }
+
+    /**
+     * Starts loading from the given URL and pass the loaded response to the `onLoad()` callback.
+     *
+     * @param {string} url - The path/URL of the file to be loaded. This can also be a data URI.
+     * @param {function(any)} onLoad - Executed when the loading process has been finished.
+     * @param {onProgressCallback} [onProgress] - Executed while the loading is in progress.
+     * @param {onErrorCallback} [onError] - Executed when errors occur.
+     * @return {any|undefined} The cached resource if available.
+     */
+    load(url, onLoad, onProgress, onError) {
+        if (url === undefined) url = "";
+
+        if (this.path !== undefined) url = this.path + url;
+
+        url = this.manager.resolveURL(url);
+
+        // copy reference at start of method in case it is changed while loading
+        const revalidatedUrls = this._revalidatedUrls;
+        const forceNoCacheRequest = revalidatedUrls
+            ? !revalidatedUrls.has(url)
+            : false;
+
+        if (!forceNoCacheRequest) {
+            const cached = Cache.get(`file:${url}`);
+
+            if (cached !== undefined) {
+                this.manager.itemStart(url);
+
+                setTimeout(() => {
+                    if (onLoad) onLoad(cached);
+                    this.manager.itemEnd(url);
+                }, 0);
+
+                return cached;
+            }
+        }
+
+        // Check if request is duplicate
+
+        let loadingEntry = loading[url];
+
+        if (
+            loadingEntry !== undefined &&
+            (!revalidatedUrls ||
+                loadingEntry.revalidatedUrls === revalidatedUrls)
+        ) {
+            loadingEntry.callbacks.push({onLoad, onProgress, onError});
+            return;
+        }
+
+        // Create new loading entry (replacing if duplicate with different revalidatedUrls)
+        loadingEntry = loading[url] = {
+            revalidatedUrls,
+            callbacks: [{onLoad, onProgress, onError}],
+        };
+
+        // create request
+        const req = new Request(url, {
+            headers: new Headers(this.requestHeader),
+            cache: forceNoCacheRequest ? "no-cache" : undefined,
+            credentials: this.withCredentials ? "include" : "same-origin",
+            signal:
+                // future versions of LoadingManager have an abortController property
+                typeof AbortSignal.any === "function" &&
+                this.manager.abortController?.signal
+                    ? AbortSignal.any([
+                          this._abortController.signal,
+                          this.manager.abortController.signal,
+                      ])
+                    : this._abortController.signal,
+        });
+
+        // record states ( avoid data race )
+        const mimeType = this.mimeType;
+        const responseType = this.responseType;
+
+        // start the fetch
+        fetch(req)
+            .then((response) => {
+                if (response.status === 200 || response.status === 0) {
+                    // Some browsers return HTTP Status 0 when using non-http protocol
+                    // e.g. 'file://' or 'data://'. Handle as success.
+
+                    if (response.status === 0) {
+                        warn("FileLoader: HTTP Status 0 received.");
+                    }
+
+                    // Workaround: Checking if response.body === undefined for Alipay browser #23548
+
+                    if (
+                        typeof ReadableStream === "undefined" ||
+                        response.body === undefined ||
+                        response.body.getReader === undefined
+                    ) {
+                        return response;
+                    }
+
+                    const reader = response.body.getReader();
+
+                    // Nginx needs X-File-Size check
+                    // https://serverfault.com/questions/482875/why-does-nginx-remove-content-length-header-for-chunked-content
+                    const contentLength =
+                        response.headers.get("X-File-Size") ||
+                        response.headers.get("Content-Length");
+                    const total = contentLength ? parseInt(contentLength) : 0;
+                    const lengthComputable = total !== 0;
+                    let loaded = 0;
+
+                    // periodically read data into the new stream tracking while download progress
+                    const stream = new ReadableStream({
+                        start(controller) {
+                            readData();
+
+                            function readData() {
+                                reader.read().then(
+                                    ({done, value}) => {
+                                        if (done) {
+                                            controller.close();
+                                        } else {
+                                            loaded += value.byteLength;
+
+                                            const event = new ProgressEvent(
+                                                "progress",
+                                                {
+                                                    lengthComputable,
+                                                    loaded,
+                                                    total,
+                                                }
+                                            );
+                                            for (
+                                                let i = 0,
+                                                    il =
+                                                        loadingEntry.callbacks
+                                                            .length;
+                                                i < il;
+                                                i++
+                                            ) {
+                                                const callback =
+                                                    loadingEntry.callbacks[i];
+                                                if (callback.onProgress)
+                                                    callback.onProgress(event);
+                                            }
+
+                                            controller.enqueue(value);
+                                            readData();
+                                        }
+                                    },
+                                    (e) => {
+                                        controller.error(e);
+                                    }
+                                );
+                            }
+                        },
+                    });
+
+                    return new Response(stream);
+                } else {
+                    throw new HttpError(
+                        `fetch for "${response.url}" responded with ${response.status}: ${response.statusText}`,
+                        response
+                    );
+                }
+            })
+            .then((response) => {
+                switch (responseType) {
+                    case "arraybuffer":
+                        return response.arrayBuffer();
+
+                    case "blob":
+                        return response.blob();
+
+                    case "document":
+                        return response.text().then((text) => {
+                            const parser = new DOMParser();
+                            return parser.parseFromString(text, mimeType);
+                        });
+
+                    case "json":
+                        return response.json();
+
+                    default:
+                        if (mimeType === "") {
+                            return response.text();
+                        } else {
+                            // sniff encoding
+                            const re = /charset="?([^;"\s]*)"?/i;
+                            const exec = re.exec(mimeType);
+                            const label =
+                                exec && exec[1]
+                                    ? exec[1].toLowerCase()
+                                    : undefined;
+                            const decoder = new TextDecoder(label);
+                            return response
+                                .arrayBuffer()
+                                .then((ab) => decoder.decode(ab));
+                        }
+                }
+            })
+            .then((data) => {
+                // Add to cache only on HTTP success, so that we do not cache
+                // error response bodies as proper responses to requests.
+                Cache.add(`file:${url}`, data);
+
+                if (loading[url] === loadingEntry) {
+                    delete loading[url];
+                }
+
+                for (
+                    let i = 0, il = loadingEntry.callbacks.length;
+                    i < il;
+                    i++
+                ) {
+                    const callback = loadingEntry.callbacks[i];
+                    if (callback.onLoad) callback.onLoad(data);
+                }
+            })
+            .catch((err) => {
+                // Abort errors and other errors are handled the same
+
+                if (loading[url] === loadingEntry) {
+                    delete loading[url];
+                }
+
+                for (
+                    let i = 0, il = loadingEntry.callbacks.length;
+                    i < il;
+                    i++
+                ) {
+                    const callback = loadingEntry.callbacks[i];
+                    if (callback.onError) callback.onError(err);
+                }
+                this.manager.itemError(url);
+            })
+            .finally(() => {
+                this.manager.itemEnd(url);
+            });
+        this.manager.itemStart(url);
+    }
+
+    /**
+     * Sets the expected response type.
+     *
+     * @param {('arraybuffer'|'blob'|'document'|'json'|'')} value - The response type.
+     * @return {FileLoader} A reference to this file loader.
+     */
+    setResponseType(value) {
+        this.responseType = value;
+        return this;
+    }
+
+    /**
+     * Sets the expected mime type of the loaded file.
+     *
+     * @param {string} value - The mime type.
+     * @return {FileLoader} A reference to this file loader.
+     */
+    setMimeType(value) {
+        this.mimeType = value;
+        return this;
+    }
+
+    /**
+     * Aborts ongoing fetch requests.
+     *
+     * @return {FileLoader} A reference to this instance.
+     */
+    abort() {
+        this._abortController.abort();
+        this._abortController = new AbortController();
+
+        return this;
+    }
+}

--- a/common/webapp/src/js/util/RevalidatingTextureLoader.js
+++ b/common/webapp/src/js/util/RevalidatingTextureLoader.js
@@ -1,0 +1,90 @@
+import {Loader, ImageLoader, Texture} from "three";
+import {RevalidatingFileLoader} from "./RevalidatingFileLoader";
+
+/**
+ * @import {TextureLoader} from "three"
+ */
+
+/**
+ * An alternative to {@link TextureLoader} for loading textures with support for
+ * forcing revalidation like {@link RevalidatingFileLoader}.
+ *
+ * Images are internally loaded via {@link ImageLoader} or
+ * {@link RevalidatingFileLoader} if an uncached request is made.
+ *
+ * ```js
+ * const loader = new RevalidatingTextureLoader();
+ * const texture = await loader.loadAsync( 'textures/land_ocean_ice_cloud_2048.jpg' );
+ *
+ * const material = new THREE.MeshBasicMaterial( { map:texture } );
+ * ```
+ */
+export class RevalidatingTextureLoader extends Loader {
+    /** @type {Set<string> | undefined} */
+    #revalidatedUrls;
+    #revalidatingFileLoader = new RevalidatingFileLoader(this.manager);
+    #imageLoader = new ImageLoader(this.manager);
+
+    /**
+     * @param {Set<string> | undefined} revalidatedUrls - If set to a Set, this
+     *   loader will revalidate URLs by setting the Request cache option to
+     *   "no-cache" for URLs not in the Set, adding them to the Set once loaded.
+     */
+    setRevalidatedUrls(revalidatedUrls) {
+        this.#revalidatedUrls = revalidatedUrls;
+        this.#revalidatingFileLoader.setRevalidatedUrls(revalidatedUrls);
+        return this;
+    }
+
+    /**
+	 * Starts loading from the given URL and pass the fully loaded texture
+	 * to the `onLoad()` callback. The method also returns a new texture object which can
+	 * directly be used for material creation. If you do it this way, the texture
+	 * may pop up in your scene once the respective loading process is finished.
+	 *
+	 * @param {string} url - The path/URL of the file to be loaded. This can also be a data URI.
+	 * @param {function(Texture<HTMLImageElement | ImageBitmap>)} onLoad - Executed when the loading process has been finished.
+	 * @param {onProgressCallback} onProgress - Unsupported in this loader.
+	 * @param {onErrorCallback} onError - Executed when errors occur.
+	 * @return {Texture<HTMLImageElement | ImageBitmap>} The texture.
+	 */
+    load(url, onLoad, onProgress, onError) {
+        // copy reference at start of method in case it is changed while loading
+        const revalidatedUrls = this.#revalidatedUrls;
+
+        const texture = new Texture();
+
+        if (revalidatedUrls && !revalidatedUrls.has(url)) {
+            const loader = this.#revalidatingFileLoader;
+            loader.setResponseType('blob');
+            loader.setWithCredentials(this.withCredentials);
+            loader.setCrossOrigin(this.crossOrigin);
+            loader.setPath(this.path);
+
+            loader.loadAsync(url, onProgress)
+                .then(async blob => {
+                    revalidatedUrls.add(url);
+
+                    const imageBitmap = await createImageBitmap(blob, {colorSpaceConversion: 'none'});
+                    texture.image = imageBitmap;
+                    texture.needsUpdate = true;
+                    return texture;
+                })
+                .then(onLoad, onError)
+        } else {
+            const loader = this.#imageLoader;
+            loader.setCrossOrigin(this.crossOrigin);
+            loader.setPath(this.path);
+
+            loader.loadAsync(url, onProgress)
+                .then(image => {
+                    texture.image = image;
+                    texture.needsUpdate = true;
+                    return texture;
+                })
+                .then(onLoad, onError);
+        }
+
+        return texture;
+    }
+}

--- a/common/webapp/src/js/util/Utils.js
+++ b/common/webapp/src/js/util/Utils.js
@@ -89,10 +89,6 @@ const splitNumberToPath = num => {
  */
 export const hashTile = (x, z) => `x${x}z${z}`;
 
-export const generateCacheHash = () => {
-    return Math.round(Math.random() * 1000000);
-}
-
 /**
  * Dispatches an event to the element of this map-viewer
  * @param element {EventTarget} the element on that the event is dispatched


### PR DESCRIPTION
This PR replaces cache-busting query parameters on all file requests to allow browsers to cache files. With this PR, if you reopen a BlueMap page that you've opened in the same area before and the assets haven't changed, then barely any network traffic will happen (ie. <1 mb instead of 15+ mb for a short peek), even if you refresh or press the "update map" button.

The browser will automatically use any cached responses that are still fresh ("fresh" meaning that the cached response is younger than its Cache-Control header's max-age value), and will issue conditional requests for any stale cached assets **if** the web server delivered the assets with an ETag or Last-Modified header (as most setups with an external webserver will do, including the setups described by the [External webservers](https://bluemap.bluecolored.de/wiki/webserver/ExternalWebserversFile.html) and [Cloudflare](https://bluemap.bluecolored.de/community/CloudflareR2.html) guides), saving bandwidth when nothing has changed by allowing the server to respond with an empty 304 response.

The "update map" button and requests made after a refresh now work by using Fetch's `cache: "no-cache"` option, which is superior to cache-busting because it allows the browser to make conditional requests if it has any (fresh or stale) cached responses.

If the web server (like BlueMap's built-in webserver) does not include ETag or Last-Modified headers in its responses, then Fetch with the `cache: "no-cache"` option works pretty similar to the current cache-busted queries.

There is one possible visible downside with this PR: on an initial non-refresh page load, the browser may use any fresh cached assets immediately without re-validating against the server, which is great for load times but may be bad if the assets were served with a large Cache-Control max-age value. BlueMap's built-in webserver sets the Cache-Control max-age to 24 hours, so someone re-opening a BlueMap within 24 hours may see assets that are up to 24 hours old (until they refresh or press the "update map" button). If this is an issue, I suggest changing BlueMap's built-in webserver to serve assets with a shorter max-age value, such as 1 hour or 10 minutes.

The one kind of hairy part of this PR is RevalidatingFileLoader.js, which is forked from Three.js's own FileLoader because it has multiple issues preventing it from being used here for this purpose (it doesn't support passing extra options to Fetch, and it can improperly de-dupe requests for the same URL made before and after pressing the "update map" button). The changes to it are pretty light and it seems to only use public APIs of Three.js, so I think it's a decent route. (I do also have an alternative hacky implementation of RevalidatingFileLoader at https://github.com/Macil/BlueMap/blob/betterCaching-monkeyPatch/common/webapp/src/js/util/RevalidatingFileLoader.js which is instead a wrapper around Three.js's FileLoader with some ugly monkey-patching. I don't trust this hacky route to be as future-proof.)