### PR TITLE
Use raw mouse input in free flight mode

### DIFF
--- a/common/webapp/src/js/controls/freeflight/FreeFlightControls.js
+++ b/common/webapp/src/js/controls/freeflight/FreeFlightControls.js
@@ -152,8 +152,16 @@ export class FreeFlightControls {
 
         document.body.requestFullscreen()
             .finally(() => {
+                // try with unadjustedMovement first and fall back without it if not supported
                 this.target.requestPointerLock({
                     unadjustedMovement: true
+                })
+                .catch(err => {
+                    if (err.name === "NotSupportedError") {
+                        return this.target.requestPointerLock();
+                    } else {
+                        throw err;
+                    }
                 });
             });
     }

--- a/common/webapp/src/js/controls/freeflight/FreeFlightControls.js
+++ b/common/webapp/src/js/controls/freeflight/FreeFlightControls.js
@@ -152,7 +152,9 @@ export class FreeFlightControls {
 
         document.body.requestFullscreen()
             .finally(() => {
-                this.target.requestPointerLock();
+                this.target.requestPointerLock({
+                    unadjustedMovement: true
+                });
             });
     }
 


### PR DESCRIPTION
This PR uses requestPointerLock's unadjustedMovement option to enable raw mouse input in full-screen free flight mode.

- Chrome supports reading raw mouse input when pointer lock is used, and it seems to be generally recommended for first-person controls to make the mouse movement's relation to your looking angle more predictable: https://web.dev/articles/disable-mouse-acceleration.
- This setting also happens to work around a Chrome bug I encounter very often. When using free flight mode in Chrome, I noticed sometimes while I looked around with the mouse, over a single frame my viewpoint would suddenly rotate far, leaving me disoriented looking in a completely different direction. I debugged this by making `MouseRotateControls.onMouseMove` log the values of `evt.movementX`, and I noticed the issue was caused by `evt.movementX` suddenly having an extreme value like -720 out of nowhere instead of its normal range of values (roughly -40 to 40). I get an incident like this about once a minute when looking around a lot in Chrome, and never in Firefox.

  I found that this is a commonly known issue in Chrome (https://github.com/wasm-bindgen/wasm-bindgen/issues/3862, https://github.com/mrdoob/three.js/issues/12757, https://github.com/Triang3l/WebQuake/issues/37, https://issues.chromium.org/issues/40547981), and this issue can be worked around by using requestPointerLock's unadjustedMovement option. It's convenient that the option that's good for first-person controls also happens to be the one that fixes this problem.