### PR TITLE
Add/Improve SQLite compatiblity

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/config/BlueMapConfigManager.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/BlueMapConfigManager.java
@@ -60,6 +60,7 @@ public class BlueMapConfigManager implements BlueMapConfiguration {
 
     public static final String FILE_STORAGE_CONFIG_NAME = STORAGES_CONFIG_FOLDER_NAME + "/file";
     public static final String SQL_STORAGE_CONFIG_NAME = STORAGES_CONFIG_FOLDER_NAME + "/sql";
+    public static final String SQLITE_STORAGE_CONFIG_NAME = STORAGES_CONFIG_FOLDER_NAME + "/sqlite";
 
     private final ConfigManager configManager;
 
@@ -348,6 +349,11 @@ public class BlueMapConfigManager implements BlueMapConfiguration {
                 Files.writeString(
                         configManager.resolveConfigFile(SQL_STORAGE_CONFIG_NAME),
                         configManager.loadConfigTemplate(SQL_STORAGE_CONFIG_NAME).build(),
+                        StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
+                );
+                Files.writeString(
+                        configManager.resolveConfigFile(SQLITE_STORAGE_CONFIG_NAME),
+                        configManager.loadConfigTemplate(SQLITE_STORAGE_CONFIG_NAME).build(),
                         StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
                 );
             } catch (IOException | NullPointerException ex) {

--- a/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
@@ -1,0 +1,204 @@
+/*
+ * This file is part of BlueMap, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Blue (Lukas Rieger) <https://bluecolored.de>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package de.bluecolored.bluemap.common.config.storage;
+
+import de.bluecolored.bluemap.common.config.ConfigurationException;
+import de.bluecolored.bluemap.common.debug.DebugDump;
+import de.bluecolored.bluemap.core.storage.compression.Compression;
+import de.bluecolored.bluemap.core.storage.sql.Database;
+import de.bluecolored.bluemap.core.storage.sql.SQLStorage;
+import de.bluecolored.bluemap.core.storage.sql.commandset.CommandSet;
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.management.RuntimeErrorException;
+
+@SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
+@ConfigSerializable
+@Getter
+public class SQLiteConfig extends StorageConfig {
+
+    @DebugDump(exclude = true)
+    private String connectionUrl = "jdbc:sqlite:file:" + Path.of("bluemap", "web") + "/map.db";
+
+    @DebugDump(exclude = true)
+    private Map<String, String> connectionProperties = new HashMap<>();
+
+    private String dialect = null;
+
+    private String driverJar = null;
+    private String driverClass = null;
+    private int maxConnections = 1;
+
+    private List<String> pragmaCommands = new ArrayList<>();
+
+    private String compression = Compression.GZIP.getKey().getFormatted();
+
+    @Getter(AccessLevel.NONE)
+    private transient URL driverJarURL = null;
+
+    public Optional<URL> getDriverJar() throws ConfigurationException {
+        try {
+            if (driverJar == null) return Optional.empty();
+
+            if (driverJarURL == null) {
+                driverJarURL = Paths.get(driverJar).toUri().toURL();
+            }
+
+            return Optional.of(driverJarURL);
+        } catch (MalformedURLException ex) {
+            throw new ConfigurationException("""
+            The configured driver-jar path is not formatted correctly!
+            Please check your 'driver-jar' setting in your configuration and make sure you have the correct path configured.
+            """.strip(), ex);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public Optional<String> getDriverClass() {
+        return Optional.ofNullable(driverClass);
+    }
+
+    public Compression getCompression() throws ConfigurationException {
+        return parseKey(Compression.REGISTRY, compression, "compression");
+    }
+
+    public Dialect getDialect() throws ConfigurationException {
+        String key = dialect;
+
+        // default from connection-url
+        if (key == null) {
+            for (Dialect d : Dialect.REGISTRY.values()) {
+                if (d.supports(connectionUrl)) {
+                    key = d.getKey().getFormatted();
+                    break;
+                }
+            }
+
+            if (key == null) throw new ConfigurationException("""
+                Could not find any sql-dialect that is matching the given connection-url.
+                Please check your 'connection-url' setting in your configuration and make sure it is in the correct format.
+                """.strip());
+        }
+
+        return parseKey(Dialect.REGISTRY, key, "dialect");
+    }
+
+    @Override
+    public SQLStorage createStorage() throws ConfigurationException {
+        Driver driver = createDriver();
+        Database database;
+        if (driver != null) {
+            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), driver);
+        } else {
+            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections());
+        }
+
+        // @TODO: Move this, or maybe just fix the exceptions?
+        // @TODO: This doesn't work because this is in a transaction, which is wrong.
+        try {
+            database.run(connection -> {
+                try (Statement stmt = connection.createStatement()) {
+                    connection.setAutoCommit(true); // @TODO: This is probably not the right solution.
+                    for (String pragmaCommand : pragmaCommands) {
+                        System.out.println("autocommit=" + connection.getAutoCommit());
+                        stmt.execute("PRAGMA " + pragmaCommand.trim());
+                    }
+                } catch (SQLException e) {
+                    throw new RuntimeException("SQL exception while running PRAGMAs!", e);
+                }
+            });
+        } catch(IOException e) {
+            throw new RuntimeException("IOException while running PRAGMAs!", e);
+        }
+        CommandSet commandSet = getDialect().createCommandSet(database);
+        return new SQLStorage(commandSet, getCompression());
+    }
+
+    private @Nullable Driver createDriver() throws ConfigurationException {
+        if (driverClass == null) return null;
+
+        try {
+            // load driver class
+            Class<?> driverClazz;
+            URL driverJarUrl = getDriverJar().orElse(null);
+            if (driverJarUrl != null) {
+
+                // sanity-check if file exists
+                if (!Files.exists(Path.of(driverJarUrl.toURI()))) {
+                    throw new ConfigurationException("""
+                    The configured driver-jar was not found!
+                    Please check your 'driver-jar' setting in your configuration and make sure you have the correct path configured.
+                    """.strip());
+                }
+
+                ClassLoader classLoader = new URLClassLoader(new URL[]{driverJarUrl});
+                driverClazz = Class.forName(driverClass, true, classLoader);
+            } else {
+                driverClazz = Class.forName(driverClass);
+            }
+
+            // create driver
+            return (Driver) driverClazz.getDeclaredConstructor().newInstance();
+        } catch (ClassCastException ex) {
+            throw new ConfigurationException("""
+            The configured driver-class was found but is not of the correct class-type!
+            Please check your 'driver-class' setting in your configuration and make sure you have the correct class configured.
+            """.strip(), ex);
+        } catch (ClassNotFoundException ex) {
+            throw new ConfigurationException("""
+            The configured driver-class was not found!
+            Please check your 'driver-class' setting in your configuration and make sure you have the correct class configured.
+            """.strip(), ex);
+        } catch (ConfigurationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new ConfigurationException("""
+            BlueMap failed to load the configured SQLite-Driver!
+            Please check your 'driver-jar' and 'driver-class' settings in your configuration.
+            """.strip(), ex);
+        }
+    }
+
+}

--- a/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
@@ -52,8 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.management.RuntimeErrorException;
-
 @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
 @ConfigSerializable
 @Getter
@@ -130,27 +128,9 @@ public class SQLiteConfig extends StorageConfig {
         Driver driver = createDriver();
         Database database;
         if (driver != null) {
-            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), driver);
+            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), driver, pragmaCommands);
         } else {
-            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections());
-        }
-
-        // @TODO: Move this, or maybe just fix the exceptions?
-        // @TODO: This doesn't work because this is in a transaction, which is wrong.
-        try {
-            database.run(connection -> {
-                try (Statement stmt = connection.createStatement()) {
-                    connection.setAutoCommit(true); // @TODO: This is probably not the right solution.
-                    for (String pragmaCommand : pragmaCommands) {
-                        System.out.println("autocommit=" + connection.getAutoCommit());
-                        stmt.execute("PRAGMA " + pragmaCommand.trim());
-                    }
-                } catch (SQLException e) {
-                    throw new RuntimeException("SQL exception while running PRAGMAs!", e);
-                }
-            });
-        } catch(IOException e) {
-            throw new RuntimeException("IOException while running PRAGMAs!", e);
+            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), pragmaCommands);
         }
         CommandSet commandSet = getDialect().createCommandSet(database);
         return new SQLStorage(commandSet, getCompression());

--- a/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
@@ -126,12 +126,21 @@ public class SQLiteConfig extends StorageConfig {
     public SQLStorage createStorage() throws ConfigurationException {
         Driver driver = createDriver();
         Database database;
-        // @TODO: Maybe make another variable called fixedPragmaCommands or something?
-        pragmaCommands.replaceAll(s -> "PRAGMA " + s); 
+        List<String> initialCommands = List.of();
+        // @TODO: Ehh, I feel like there should be a better way of doing this
+        String pragmaPrefix = "PRAGMA";
+
+        // Prefix all pragma commands with PRAGMA if they don't already start with it
+        initialCommands.addAll(
+            pragmaCommands.stream()
+                .map(s -> s.startsWith(pragmaPrefix) ? s: pragmaPrefix + s)
+                .toList()
+        );
+
         if (driver != null) {
-            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), driver, pragmaCommands);
+            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), driver, initialCommands);
         } else {
-            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), pragmaCommands);
+            database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), initialCommands);
         }
         CommandSet commandSet = getDialect().createCommandSet(database);
         return new SQLStorage(commandSet, getCompression());

--- a/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
@@ -35,17 +35,13 @@ import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.sql.Driver;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -127,6 +123,8 @@ public class SQLiteConfig extends StorageConfig {
     public SQLStorage createStorage() throws ConfigurationException {
         Driver driver = createDriver();
         Database database;
+        // @TODO: Maybe make another variable called fixedPragmaCommands or something?
+        pragmaCommands.replaceAll(s -> "PRAGMA " + s); 
         if (driver != null) {
             database = new Database(getConnectionUrl(), getConnectionProperties(), getMaxConnections(), driver, pragmaCommands);
         } else {

--- a/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/storage/SQLiteConfig.java
@@ -53,8 +53,11 @@ import java.util.Optional;
 @Getter
 public class SQLiteConfig extends StorageConfig {
 
+    // @TODO: There must be some better way to do this..
+    private String fileLocation = "bluemap/map.db";
+
     @DebugDump(exclude = true)
-    private String connectionUrl = "jdbc:sqlite:file:" + Path.of("bluemap", "web") + "/map.db";
+    private String connectionUrl = "jdbc:sqlite:file:" + fileLocation;
 
     @DebugDump(exclude = true)
     private Map<String, String> connectionProperties = new HashMap<>();

--- a/common/src/main/java/de/bluecolored/bluemap/common/config/storage/StorageType.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/storage/StorageType.java
@@ -34,10 +34,12 @@ public interface StorageType extends Keyed {
 
     StorageType FILE = new Impl(Key.bluemap("file"), FileConfig.class);
     StorageType SQL = new Impl(Key.bluemap("sql"), SQLConfig.class);
+    StorageType SQLITE = new Impl(Key.bluemap("sqlite"), SQLiteConfig.class);
 
     Registry<StorageType> REGISTRY = new Registry<>(
             FILE,
-            SQL
+            SQL,
+            SQLITE
     );
 
     Class<? extends StorageConfig> getConfigType();

--- a/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
@@ -16,7 +16,7 @@ file-location: "bluemap/map.db"
 # Find PRAGMA command documentation at https://sqlite.org/pragma.html
 # Some commands may improve render performance, hurt render performance, introduce possibly of corruption, use more RAM, etc.
 # Add/change commands cautiously!
-pragma-commands = [
+pragma-commands: [
   "journal_mode = WAL"
   "journal_size_limit = 268435456"
 #  "cache_size = -65536" # Will use more RAM, but otherwise generally improves read performance when multiple people are browsing the map.

--- a/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
@@ -21,6 +21,7 @@ pragma-commands: [
   "journal_size_limit = 268435456"
 #  "cache_size = -65536" # Will use more RAM, but otherwise generally improves read performance when multiple people are browsing the map.
 #  "synchronous = NORMAL" # ONLY SAFE TO USE WITH WAL! Otherwise improves write performance while rendering.
+#  "cell_size_check = ON" # Detects corruption earlier and makes it less likely to "spread", comes with a small performance penalty!
 ]
 
 # This can be used to load a custom JDBC-Driver from a .jar file.

--- a/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
@@ -8,10 +8,9 @@
 # Don't change this value! If you want a different storage-type, check out the other example configs.
 storage-type: sqlite
 
-# The JDBC-Connection URL that is used to connect to the database.
-# The format for this URL is usually something like: jdbc:sqlite:file:[folder/file]/[folder/file]
-# The default is: "bluemap/maps"
-connection-url: "jdbc:sqlite:file:bluemap/map.db"
+# The location of the SQLite database file.
+# The default is: "bluemap/map.db"
+file-location: "bluemap/map.db"
 
 # The PRAGMA commands to run on initialization.
 # Find PRAGMA command documentation at https://sqlite.org/pragma.html

--- a/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
@@ -9,16 +9,19 @@
 storage-type: sqlite
 
 # The JDBC-Connection URL that is used to connect to the database.
-# The format for this URL is usually something like: jdbc:[driver]://[host]:[port]/[database]
+# The format for this URL is usually something like: jdbc:sqlite:file:[folder/file]/[folder/file]
 # The exact format of the URL is determined by the JDBC-Driver you are using.
 connection-url: "jdbc:sqlite:file:bluemap/map.db"
 
-# The PRAGMA commands to run on the inital connection.
-# Find PRAGMA commands at https://sqlite.org/pragma.html/
+# The PRAGMA commands to run on initialization.
+# Find PRAGMA command documentation at https://sqlite.org/pragma.html
+# Some commands may improve render performance, hurt render performance, introduce possibly of corruption, use more RAM, etc.
+# Add/change commands cautiously!
 pragma-commands:
   - "journal_mode = WAL"
-  - "cache_size = -20000"
-  - "synchronous = NORMAL"
+  - "journal_size_limit = 268435456"
+#  - "cache_size = -65536" # Will use more RAM, but otherwise generally improves read performance when multiple people are browsing the map.
+#  - "synchronous = NORMAL" # ONLY SAFE TO USE WITH WAL! Otherwise improves write performance while rendering.
 
 # This can be used to load a custom JDBC-Driver from a .jar file.
 # E.g. if your runtime environment is not already providing an SQLite driver,

--- a/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
@@ -1,0 +1,43 @@
+##                          ##
+##         BlueMap          ##
+##      Storage-Config      ##
+##                          ##
+
+# The storage-type of this storage.
+# Depending on this setting, different config entries are allowed/expected in this config file.
+# Don't change this value! If you want a different storage-type, check out the other example configs.
+storage-type: sqlite
+
+# The JDBC-Connection URL that is used to connect to the database.
+# The format for this URL is usually something like: jdbc:[driver]://[host]:[port]/[database]
+# The exact format of the URL is determined by the JDBC-Driver you are using.
+connection-url: "jdbc:sqlite:file:bluemap/map.db"
+
+# The PRAGMA commands to run on the inital connection.
+# Find PRAGMA commands at https://sqlite.org/pragma.html/
+pragma-commands:
+  - "journal_mode = WAL"
+  - "cache_size = -20000"
+  - "synchronous = NORMAL"
+
+# This can be used to load a custom JDBC-Driver from a .jar file.
+# E.g. if your runtime environment is not already providing an SQLite driver,
+# you could download the SQLite JDBC-Connector from https://github.com/xerial/sqlite-jdbc/releases/
+# If you set this value, you HAVE TO set the correct driver-class name below.
+# Place it in the './bluemap' folder and use it like this:
+#driver-jar: "bluemap/sqlite-jdbc-2.51.2.0"
+
+# This is the driver-class that BlueMap will try to load and use.
+# Check the documentation of the driver you are using if you don't know this.
+# Leaving this commented out means that BlueMap automatically tries to find a suitable driver in your classpath.
+# If you added a custom driver-jar value above, you HAVE TO set the correct class name here.
+#driver-class: "org.sqlite.JDBC"
+
+# The compression type that BlueMap will use to compress generated map data.
+# Available compression types are:
+#  - gzip
+#  - zstd
+#  - deflate
+#  - none
+# The default is: gzip
+compression: gzip

--- a/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/storages/sqlite.conf
@@ -10,25 +10,26 @@ storage-type: sqlite
 
 # The JDBC-Connection URL that is used to connect to the database.
 # The format for this URL is usually something like: jdbc:sqlite:file:[folder/file]/[folder/file]
-# The exact format of the URL is determined by the JDBC-Driver you are using.
+# The default is: "bluemap/maps"
 connection-url: "jdbc:sqlite:file:bluemap/map.db"
 
 # The PRAGMA commands to run on initialization.
 # Find PRAGMA command documentation at https://sqlite.org/pragma.html
 # Some commands may improve render performance, hurt render performance, introduce possibly of corruption, use more RAM, etc.
 # Add/change commands cautiously!
-pragma-commands:
-  - "journal_mode = WAL"
-  - "journal_size_limit = 268435456"
-#  - "cache_size = -65536" # Will use more RAM, but otherwise generally improves read performance when multiple people are browsing the map.
-#  - "synchronous = NORMAL" # ONLY SAFE TO USE WITH WAL! Otherwise improves write performance while rendering.
+pragma-commands = [
+  "journal_mode = WAL"
+  "journal_size_limit = 268435456"
+#  "cache_size = -65536" # Will use more RAM, but otherwise generally improves read performance when multiple people are browsing the map.
+#  "synchronous = NORMAL" # ONLY SAFE TO USE WITH WAL! Otherwise improves write performance while rendering.
+]
 
 # This can be used to load a custom JDBC-Driver from a .jar file.
 # E.g. if your runtime environment is not already providing an SQLite driver,
 # you could download the SQLite JDBC-Connector from https://github.com/xerial/sqlite-jdbc/releases/
 # If you set this value, you HAVE TO set the correct driver-class name below.
 # Place it in the './bluemap' folder and use it like this:
-#driver-jar: "bluemap/sqlite-jdbc-2.51.2.0"
+#driver-jar: "bluemap/sqlite-jdbc-3.51.2.0.jar"
 
 # This is the driver-class that BlueMap will try to load and use.
 # Check the documentation of the driver you are using if you don't know this.

--- a/common/webapp/public/sql.php
+++ b/common/webapp/public/sql.php
@@ -149,7 +149,7 @@ if (startsWith($path, "/maps/")) {
     // Initialize PDO
     try {
         if ($driver === "sqlite") {
-            $sql = new PDO("$driver:file:$sqlfile?mode=ro");
+            $sql = new PDO("$driver:file:$sqlfile");
         } else {
             $sql = new PDO("$driver:host=$hostname;port=$port;dbname=$database", $username, $password);
         }

--- a/common/webapp/public/sql.php
+++ b/common/webapp/public/sql.php
@@ -3,7 +3,7 @@
 // !!! SET YOUR SQL-CONNECTION SETTINGS HERE: !!!
 
 $driver   = 'mysql'; // 'mysql' (MySQL), 'pgsql' (PostgreSQL) or 'sqlite' (SQLite)
-$sqlfile  = 'bluemap.db'; // Only applies when using 'sqlite' as the driver
+$sqlfile  = 'map.db'; // Only applies when using 'sqlite' as the driver
 $hostname = '127.0.0.1';
 $port     = 3306;
 $username = 'root';

--- a/common/webapp/public/sql.php
+++ b/common/webapp/public/sql.php
@@ -2,7 +2,8 @@
 
 // !!! SET YOUR SQL-CONNECTION SETTINGS HERE: !!!
 
-$driver   = 'mysql'; // 'mysql' (MySQL) or 'pgsql' (PostgreSQL)
+$driver   = 'mysql'; // 'mysql' (MySQL), 'pgsql' (PostgreSQL) or 'sqlite' (SQLite)
+$sqlfile  = 'bluemap.db'; // Only applies when using 'sqlite' as the driver
 $hostname = '127.0.0.1';
 $port     = 3306;
 $username = 'root';
@@ -147,7 +148,11 @@ if (startsWith($path, "/maps/")) {
 
     // Initialize PDO
     try {
-        $sql = new PDO("$driver:host=$hostname;port=$port;dbname=$database", $username, $password);
+        if ($driver === "sqlite") {
+            $sql = new PDO("$driver:file:$sqlfile?mode=ro");
+        } else {
+            $sql = new PDO("$driver:host=$hostname;port=$port;dbname=$database", $username, $password);
+        }
         $sql->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     } catch (PDOException $e ) { 
         error_log($e->getMessage(), 0); // Logs the detailed error message

--- a/core/src/main/java/de/bluecolored/bluemap/core/storage/sql/Database.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/storage/sql/Database.java
@@ -39,7 +39,10 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
+import java.sql.Statement;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -51,13 +54,21 @@ public class Database implements Closeable {
     private boolean isClosed = false;
 
     public Database(String url, Map<String, String> properties, int maxPoolSize) {
-        Properties props = new Properties();
-        props.putAll(properties);
-
-        this.dataSource = createDataSource(new DriverManagerConnectionFactory(url, props), maxPoolSize);
+        this(url, properties, maxPoolSize, List.of());
     }
 
     public Database(String url, Map<String, String> properties, int maxPoolSize, Driver driver) {
+        this(url, properties, maxPoolSize, driver, List.of());
+    }
+
+    public Database(String url, Map<String, String> properties, int maxPoolSize, List<String> initialCommands) {
+        Properties props = new Properties();
+        props.putAll(properties);
+
+        this.dataSource = createDataSource(new DriverManagerConnectionFactory(url, props), maxPoolSize, initialCommands);
+    }
+
+    public Database(String url, Map<String, String> properties, int maxPoolSize, Driver driver, List<String> initialCommands) {
         Properties props = new Properties();
         props.putAll(properties);
 
@@ -67,7 +78,7 @@ public class Database implements Closeable {
                 props
         );
 
-        this.dataSource = createDataSource(connectionFactory, maxPoolSize);
+        this.dataSource = createDataSource(connectionFactory, maxPoolSize, initialCommands);
     }
 
     public void run(ConnectionConsumer action) throws IOException {
@@ -121,11 +132,18 @@ public class Database implements Closeable {
         }
     }
 
-    private DataSource createDataSource(ConnectionFactory connectionFactory, int maxPoolSize) {
+    private DataSource createDataSource(ConnectionFactory connectionFactory, int maxPoolSize, List<String> initialCommands) {
         PoolableConnectionFactory poolableConnectionFactory =
                 new PoolableConnectionFactory(() -> {
                     Logger.global.logDebug("Creating new SQL-Connection...");
-                    return connectionFactory.createConnection();
+                    Connection conn = connectionFactory.createConnection();
+                    try (Statement stmt = conn.createStatement()) {
+                        for (String initialCommand : initialCommands) {
+                            Logger.global.logDebug("autocommit=" + conn.getAutoCommit());
+                            stmt.execute(initialCommand);
+                        }
+                    }
+                    return conn;
                 }, null);
         poolableConnectionFactory.setPoolStatements(true);
         poolableConnectionFactory.setMaxOpenPreparedStatements(20);

--- a/core/src/main/java/de/bluecolored/bluemap/core/storage/sql/Database.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/storage/sql/Database.java
@@ -41,7 +41,6 @@ import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
 import java.sql.Statement;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;

--- a/core/src/main/java/de/bluecolored/bluemap/core/storage/sql/Database.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/storage/sql/Database.java
@@ -52,6 +52,8 @@ public class Database implements Closeable {
     private final DataSource dataSource;
     private boolean isClosed = false;
 
+    // @TODO: Figure out some better way to pass initialCommands rather than this.
+
     public Database(String url, Map<String, String> properties, int maxPoolSize) {
         this(url, properties, maxPoolSize, List.of());
     }

--- a/core/src/main/java/de/bluecolored/bluemap/core/storage/sql/Database.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/storage/sql/Database.java
@@ -140,7 +140,6 @@ public class Database implements Closeable {
                     Connection conn = connectionFactory.createConnection();
                     try (Statement stmt = conn.createStatement()) {
                         for (String initialCommand : initialCommands) {
-                            Logger.global.logDebug("autocommit=" + conn.getAutoCommit());
                             stmt.execute(initialCommand);
                         }
                     }


### PR DESCRIPTION
This PR aims to add or improve compatibility/usage for SQLite databases.
While the BlueMap base already technically supports SQLite, certain parts (such as the sql.php script) do not.

Compatibility todo:
- [x] sql.php
- [x] BlueMap base

Options that should be added, in order of how important they probably are (None of them should require any internal code changes?):
- [x] ~~Option for enabling WAL (`PRAGMA journal_mode = WAL;`, definitely most important imo)~~
- [x] ~~Option(s?) for increasing cache size (`PRAGMA cache_size = -20000;`, negative means kilobytes, so 20MB cache, should be configurable though)~~
- [x] ~~Option for decreasing syncs (`PRAGMA synchronous = NORMAL;`, only safe to use with WAL, might lose the latest transactions on sudden power loss, but shouldn't corrupt the DB itself)~~
- [x] ~~Option for storing temporary tables in RAM (`PRAGMA temp_store = memory;`, not necessary with proper indexing)~~

^ All options can be added by the user now

Other todo:
- [x] Limit max-connections to 1 if using SQLite (Using more doesn't have any performance benefit in my testing, and is just more likely to hit annoying `SQLITE_BUSY` errors, even if using WAL)
- [ ] All `@TODO`s solved