### PR TITLE
feat: live daylight cycle — track server time with Live/Day/Night toggle

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/live/LiveWorldDataSupplier.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/live/LiveWorldDataSupplier.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of BlueMap, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Blue (Lukas Rieger) <https://bluecolored.de>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package de.bluecolored.bluemap.common.live;
+
+import com.google.gson.stream.JsonWriter;
+import de.bluecolored.bluemap.common.serverinterface.Server;
+import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
+import de.bluecolored.bluemap.core.logger.Logger;
+import de.bluecolored.bluemap.core.world.World;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.function.Supplier;
+
+public class LiveWorldDataSupplier implements Supplier<String> {
+
+    private final Server server;
+    private final World world;
+
+    private transient @Nullable ServerWorld serverWorld;
+
+    public LiveWorldDataSupplier(Server server, World world) {
+        this.server = server;
+        this.world = world;
+    }
+
+    @Override
+    public String get() {
+        if (serverWorld == null)
+            serverWorld = server.getServerWorld(world).orElse(null);
+
+        try (StringWriter jsonString = new StringWriter();
+             JsonWriter json = new JsonWriter(jsonString)) {
+
+            json.beginObject();
+            json.name("timeOfDay").value(serverWorld != null ? serverWorld.getTimeOfDay() : 6000L);
+            json.endObject();
+
+            json.flush();
+            return jsonString.toString();
+        } catch (IOException ex) {
+            Logger.global.logError("Failed to write live/world json!", ex);
+            return "BlueMap - Exception handling this request";
+        }
+    }
+
+}

--- a/common/src/main/java/de/bluecolored/bluemap/common/serverinterface/ServerWorld.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/serverinterface/ServerWorld.java
@@ -48,4 +48,13 @@ public interface ServerWorld {
         return false;
     }
 
+    /**
+     * Returns the current in-game time of day in ticks (0–23999).
+     * 0 = sunrise, 6000 = noon, 12000 = sunset, 18000 = midnight.
+     * Returns 6000 (noon) by default for platforms that do not implement this.
+     */
+    default long getTimeOfDay() {
+        return 6000L;
+    }
+
 }

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/MapRequestHandler.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/MapRequestHandler.java
@@ -27,6 +27,7 @@ package de.bluecolored.bluemap.common.web;
 import de.bluecolored.bluemap.common.config.PluginConfig;
 import de.bluecolored.bluemap.common.live.LiveMarkersDataSupplier;
 import de.bluecolored.bluemap.common.live.LivePlayersDataSupplier;
+import de.bluecolored.bluemap.common.live.LiveWorldDataSupplier;
 import de.bluecolored.bluemap.common.serverinterface.Server;
 import de.bluecolored.bluemap.common.serverinterface.ServerWorld;
 import de.bluecolored.bluemap.core.map.BmMap;
@@ -43,16 +44,18 @@ public class MapRequestHandler extends RoutingRequestHandler {
     public MapRequestHandler(BmMap map, Server serverInterface, PluginConfig pluginConfig, Predicate<UUID> playerFilter) {
         this(map.getStorage(),
                 new LivePlayersDataSupplier(serverInterface, pluginConfig, map.getWorld(), playerFilter),
-                new LiveMarkersDataSupplier(map.getMarkerSets()));
+                new LiveMarkersDataSupplier(map.getMarkerSets()),
+                new LiveWorldDataSupplier(serverInterface, map.getWorld()));
     }
 
     public MapRequestHandler(MapStorage mapStorage) {
-        this(mapStorage, null, null);
+        this(mapStorage, null, null, null);
     }
 
     public MapRequestHandler(MapStorage mapStorage,
                              @Nullable Supplier<String> livePlayersDataSupplier,
-                             @Nullable Supplier<String> liveMarkerDataSupplier) {
+                             @Nullable Supplier<String> liveMarkerDataSupplier,
+                             @Nullable Supplier<String> liveWorldDataSupplier) {
 
         register(".*", new MapStorageRequestHandler(mapStorage));
 
@@ -65,6 +68,12 @@ public class MapRequestHandler extends RoutingRequestHandler {
         if (liveMarkerDataSupplier != null) {
             register("live/markers\\.json", "", new JsonDataRequestHandler(
                     new CachedRateLimitDataSupplier(liveMarkerDataSupplier,10000)
+            ));
+        }
+
+        if (liveWorldDataSupplier != null) {
+            register("live/world\\.json", "", new JsonDataRequestHandler(
+                    new CachedRateLimitDataSupplier(liveWorldDataSupplier, 5000)
             ));
         }
     }

--- a/common/webapp/public/lang/en.conf
+++ b/common/webapp/public/lang/en.conf
@@ -49,7 +49,10 @@
   lighting: {
     title: "Lighting"
     dayNightSwitch: {
-      tooltip: "Day/Night"
+      tooltip: "Lighting Mode"
+      day: "Day"
+      live: "Live (Server Time)"
+      night: "Night"
     }
     sunlight: "Sunlight"
     ambientLight: "Ambient-Light"

--- a/common/webapp/src/components/ControlBar/DayNightSwitch.vue
+++ b/common/webapp/src/components/ControlBar/DayNightSwitch.vue
@@ -66,6 +66,7 @@ export default {
             mapViewer: this.$bluemap.mapViewer.data,
             mode: initialMode(),
             _liveTimer: null,
+            _firstLiveFetch: true,
         }
     },
     computed: {
@@ -74,11 +75,19 @@ export default {
         }
     },
     watch: {
+        // When a new map is selected, restart the poll with its URL
         currentMap(newMap, oldMap) {
-            if (this.mode === 'live' && newMap !== oldMap) {
+            if (this.mode === 'live' && newMap && newMap !== oldMap) {
                 this.stopLivePoll();
-                this.fetchAndApplyTime();
+                this._firstLiveFetch = true;
                 this._liveTimer = setInterval(() => this.fetchAndApplyTime(), LIVE_POLL_INTERVAL);
+            }
+        },
+        // MapViewer resets sunlightStrength when a map finishes loading — re-apply live time
+        'mapViewer.mapState'(newState) {
+            if (newState === 'loaded' && this.mode === 'live') {
+                this._firstLiveFetch = true;
+                this.fetchAndApplyTime();
             }
         }
     },
@@ -107,6 +116,7 @@ export default {
             } else if (newMode === 'night') {
                 this.animateTo(SUNLIGHT_NIGHT, 300);
             } else if (newMode === 'live') {
+                this._firstLiveFetch = true;
                 this.fetchAndApplyTime();
                 this._liveTimer = setInterval(() => this.fetchAndApplyTime(), LIVE_POLL_INTERVAL);
             }
@@ -130,7 +140,14 @@ export default {
                 if (!response.ok) return;
                 const data = await response.json();
                 if (typeof data.timeOfDay === 'number') {
-                    this.animateTo(timeToSunlight(data.timeOfDay), 2000);
+                    const target = timeToSunlight(data.timeOfDay);
+                    if (this._firstLiveFetch) {
+                        this._firstLiveFetch = false;
+                        this.mapViewer.uniforms.sunlightStrength.value = target;
+                        this.$bluemap.mapViewer.redraw();
+                    } else {
+                        this.animateTo(target, 2000);
+                    }
                 }
             } catch {
                 // endpoint unavailable — stay at current lighting

--- a/common/webapp/src/components/ControlBar/DayNightSwitch.vue
+++ b/common/webapp/src/components/ControlBar/DayNightSwitch.vue
@@ -1,71 +1,165 @@
 <template>
-  <SvgButton class="day-night-switch" :active="!isDay" @action="action">
-    <svg viewBox="0 0 30 30">
-      <path d="M17.011,19.722c-3.778-1.613-5.533-5.982-3.921-9.76c0.576-1.348,1.505-2.432,2.631-3.204
-        c-3.418-0.243-6.765,1.664-8.186,4.992c-1.792,4.197,0.159,9.053,4.356,10.844c3.504,1.496,7.462,0.377,9.717-2.476
-        C20.123,20.465,18.521,20.365,17.011,19.722z"/>
-      <circle cx="5.123" cy="7.64" r="1.196"/>
-      <circle cx="23.178" cy="5.249" r="1.195"/>
-      <circle cx="20.412" cy="13.805" r="1.195"/>
-      <circle cx="25.878" cy="23.654" r="1.195"/>
-    </svg>
-  </SvgButton>
+  <div class="lighting-switch">
+    <SvgButton :active="mode === 'live'" :title="$t('lighting.dayNightSwitch.live')" @action="setMode('live')">
+      <svg viewBox="0 0 30 30">
+        <path fill-rule="evenodd" d="M15,4 a11,11 0 1,0 0.001,0 Z M15,7.5 a7.5,7.5 0 1,1 -0.001,0 Z"/>
+        <rect x="13.8" y="9" width="2.4" height="6" rx="1.2" transform="rotate(-60 15 15)"/>
+        <rect x="13.8" y="9" width="2.4" height="6" rx="1.2"/>
+        <circle cx="15" cy="15" r="1.5"/>
+      </svg>
+    </SvgButton>
+    <SvgButton :active="mode === 'day'" :title="$t('lighting.dayNightSwitch.day')" @action="setMode('day')">
+      <svg viewBox="0 0 30 30">
+        <circle cx="15" cy="15" r="4.5"/>
+        <rect x="13.5" y="1.5" width="3" height="4.5" rx="1.5"/>
+        <rect x="13.5" y="1.5" width="3" height="4.5" rx="1.5" transform="rotate(45 15 15)"/>
+        <rect x="13.5" y="1.5" width="3" height="4.5" rx="1.5" transform="rotate(90 15 15)"/>
+        <rect x="13.5" y="1.5" width="3" height="4.5" rx="1.5" transform="rotate(135 15 15)"/>
+        <rect x="13.5" y="1.5" width="3" height="4.5" rx="1.5" transform="rotate(180 15 15)"/>
+        <rect x="13.5" y="1.5" width="3" height="4.5" rx="1.5" transform="rotate(225 15 15)"/>
+        <rect x="13.5" y="1.5" width="3" height="4.5" rx="1.5" transform="rotate(270 15 15)"/>
+        <rect x="13.5" y="1.5" width="3" height="4.5" rx="1.5" transform="rotate(315 15 15)"/>
+      </svg>
+    </SvgButton>
+    <SvgButton :active="mode === 'night'" :title="$t('lighting.dayNightSwitch.night')" @action="setMode('night')">
+      <svg viewBox="0 0 30 30">
+        <path d="M17.011,19.722c-3.778-1.613-5.533-5.982-3.921-9.76c0.576-1.348,1.505-2.432,2.631-3.204
+          c-3.418-0.243-6.765,1.664-8.186,4.992c-1.792,4.197,0.159,9.053,4.356,10.844c3.504,1.496,7.462,0.377,9.717-2.476
+          C20.123,20.465,18.521,20.365,17.011,19.722z"/>
+        <circle cx="5.123" cy="7.64" r="1.196"/>
+        <circle cx="23.178" cy="5.249" r="1.195"/>
+        <circle cx="20.412" cy="13.805" r="1.195"/>
+        <circle cx="25.878" cy="23.654" r="1.195"/>
+      </svg>
+    </SvgButton>
+  </div>
 </template>
 
 <script>
 import {animate, EasingFunctions} from "../../js/util/Utils";
 import SvgButton from "./SvgButton.vue";
 
+const SUNLIGHT_DAY = 1;
+const SUNLIGHT_NIGHT = 0.25;
+const LIVE_POLL_INTERVAL = 5000;
+const VALID_MODES = ['live', 'day', 'night'];
+
+function timeToSunlight(time) {
+    const t = ((time % 24000) + 24000) % 24000;
+    const angle = (t - 6000) * 2 * Math.PI / 24000;
+    return 0.25 + 0.75 * Math.max(0, (Math.cos(angle) + 1) / 2);
+}
+
+function initialMode() {
+    const param = new URLSearchParams(window.location.search).get('lighting');
+    return VALID_MODES.includes(param) ? param : 'live';
+}
+
 let animation;
 
 export default {
     name: "DayNightSwitch",
-  components: {SvgButton},
-  data() {
-      return {
-        mapViewer: this.$bluemap.mapViewer.data
-      }
+    components: {SvgButton},
+    inheritAttrs: false,
+    data() {
+        return {
+            mapViewer: this.$bluemap.mapViewer.data,
+            mode: initialMode(),
+            _liveTimer: null,
+        }
     },
     computed: {
-      isDay() {
-        return this.mapViewer.uniforms.sunlightStrength.value > 0.6;
-      }
+        currentMap() {
+            return this.mapViewer.map;
+        }
+    },
+    watch: {
+        currentMap(newMap, oldMap) {
+            if (this.mode === 'live' && newMap !== oldMap) {
+                this.stopLivePoll();
+                this.fetchAndApplyTime();
+                this._liveTimer = setInterval(() => this.fetchAndApplyTime(), LIVE_POLL_INTERVAL);
+            }
+        }
+    },
+    mounted() {
+        // apply initial mode without requiring a click
+        if (this.mode === 'live') {
+            this.fetchAndApplyTime();
+            this._liveTimer = setInterval(() => this.fetchAndApplyTime(), LIVE_POLL_INTERVAL);
+        } else if (this.mode === 'day') {
+            this.animateTo(SUNLIGHT_DAY, 300);
+        } else if (this.mode === 'night') {
+            this.animateTo(SUNLIGHT_NIGHT, 300);
+        }
+    },
+    beforeUnmount() {
+        this.stopLivePoll();
     },
     methods: {
-      action(evt) {
+        setMode(newMode) {
+            if (this.mode === newMode) return;
+            this.mode = newMode;
+            this.stopLivePoll();
 
-        evt.preventDefault();
-
-        if (animation) animation.cancel();
-
-        let startValue = this.mapViewer.uniforms.sunlightStrength.value;
-        let targetValue = this.isDay ? 0.25 : 1;
-        animation = animate(t => {
-          let u = EasingFunctions.easeOutQuad(t);
-          this.mapViewer.uniforms.sunlightStrength.value = startValue * (1-u) + targetValue * u;
-          this.$bluemap.mapViewer.redraw();
-        }, 300);
-      }
+            if (newMode === 'day') {
+                this.animateTo(SUNLIGHT_DAY, 300);
+            } else if (newMode === 'night') {
+                this.animateTo(SUNLIGHT_NIGHT, 300);
+            } else if (newMode === 'live') {
+                this.fetchAndApplyTime();
+                this._liveTimer = setInterval(() => this.fetchAndApplyTime(), LIVE_POLL_INTERVAL);
+            }
+        },
+        animateTo(target, duration) {
+            const current = this.mapViewer.uniforms.sunlightStrength.value;
+            if (Math.abs(current - target) < 0.005) return;
+            if (animation) animation.cancel();
+            const start = current;
+            animation = animate(t => {
+                const u = EasingFunctions.easeOutQuad(t);
+                this.mapViewer.uniforms.sunlightStrength.value = start * (1 - u) + target * u;
+                this.$bluemap.mapViewer.redraw();
+            }, duration);
+        },
+        async fetchAndApplyTime() {
+            const map = this.currentMap;
+            if (!map) return;
+            try {
+                const response = await fetch(map.liveDataRoot + "/live/world.json", {cache: "no-store"});
+                if (!response.ok) return;
+                const data = await response.json();
+                if (typeof data.timeOfDay === 'number') {
+                    this.animateTo(timeToSunlight(data.timeOfDay), 2000);
+                }
+            } catch {
+                // endpoint unavailable — stay at current lighting
+            }
+        },
+        stopLivePoll() {
+            if (this._liveTimer) {
+                clearInterval(this._liveTimer);
+                this._liveTimer = null;
+            }
+        }
     }
-  }
+}
 </script>
 
 <style lang="scss">
-  .day-night-switch {
-    svg {
-      fill: var(--theme-moon-day);
-      circle {
-        fill: var(--theme-stars-day);
-      }
-    }
+.lighting-switch {
+    display: flex;
 
-    &:active {
-      svg {
-        fill: var(--theme-moon-night);
-        circle {
-          fill: var(--theme-stars-night);
+    .svg-button {
+        min-width: 1.5em;
+
+        svg {
+            fill: var(--theme-fg-light);
         }
-      }
+
+        &.active svg {
+            fill: var(--theme-fg);
+        }
     }
-  }
+}
 </style>

--- a/implementations/fabric/src/main/java/de/bluecolored/bluemap/fabric/FabricWorld.java
+++ b/implementations/fabric/src/main/java/de/bluecolored/bluemap/fabric/FabricWorld.java
@@ -91,6 +91,13 @@ public class FabricWorld implements ServerWorld {
     }
 
     @Override
+    public long getTimeOfDay() {
+        net.minecraft.server.level.ServerLevel world = delegate.get();
+        if (world == null) return 6000L;
+        return world.getOverworldClockTime() % 24000L;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/implementations/forge/src/main/java/de/bluecolored/bluemap/forge/ForgeWorld.java
+++ b/implementations/forge/src/main/java/de/bluecolored/bluemap/forge/ForgeWorld.java
@@ -94,6 +94,13 @@ public class ForgeWorld implements ServerWorld {
     }
 
     @Override
+    public long getTimeOfDay() {
+        ServerLevel world = delegate.get();
+        if (world == null) return 6000L;
+        return world.getOverworldClockTime() % 24000L;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/implementations/neoforge/src/main/java/de/bluecolored/bluemap/forge/ForgeWorld.java
+++ b/implementations/neoforge/src/main/java/de/bluecolored/bluemap/forge/ForgeWorld.java
@@ -94,6 +94,13 @@ public class ForgeWorld implements ServerWorld {
     }
 
     @Override
+    public long getTimeOfDay() {
+        ServerLevel world = delegate.get();
+        if (world == null) return 6000L;
+        return world.getOverworldClockTime() % 24000L;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/implementations/paper/src/main/java/de/bluecolored/bluemap/bukkit/BukkitWorld.java
+++ b/implementations/paper/src/main/java/de/bluecolored/bluemap/bukkit/BukkitWorld.java
@@ -87,6 +87,13 @@ public class BukkitWorld implements ServerWorld {
     }
 
     @Override
+    public long getTimeOfDay() {
+        org.bukkit.World world = delegate.get();
+        if (world == null) return 6000L;
+        return world.getTime();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/implementations/spigot/src/main/java/de/bluecolored/bluemap/bukkit/BukkitWorld.java
+++ b/implementations/spigot/src/main/java/de/bluecolored/bluemap/bukkit/BukkitWorld.java
@@ -98,6 +98,13 @@ public class BukkitWorld implements ServerWorld {
     }
 
     @Override
+    public long getTimeOfDay() {
+        World world = delegate.get();
+        if (world == null) return 6000L;
+        return world.getTime();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;


### PR DESCRIPTION
Closes #398

## Summary

Adds a **Live** lighting mode that tracks the server's in-game world time and smoothly transitions the map's sunlight to match — so the map darkens at night and brightens at noon in real time.

Live is the default mode. Users can also lock to **Day** or **Night** manually, or use a URL param to override the default for embeds.

## Changes

### Java
- `ServerWorld.getTimeOfDay()` — new interface method returning in-game time of day (0–23999); defaults to 6000 (noon) so platforms that don't implement it stay at full day
- Implemented on all platforms:
  - Fabric / Forge / NeoForge: `getOverworldClockTime() % 24000`
  - Bukkit / Paper: `World.getTime()`
- `LiveWorldDataSupplier` — new supplier emitting `{"timeOfDay": N}`
- `MapRequestHandler` — registers `live/world.json` with a 5s cache

### Webapp
- `DayNightSwitch` replaced with a **Live | Day | Night** 3-button control
- Live mode polls `live/world.json` every 5s and animates `sunlightStrength` via a cosine curve: noon (tick 6000) → 1.0, midnight (tick 18000) → 0.25
- `?lighting=day|night|live` URL param overrides the default (live) — useful for embeds
- Falls back silently when the endpoint is unavailable (static/read-only deploys)

## Lighting curve

```
sunlight = 0.25 + 0.75 * max(0, (cos((tick - 6000) × 2π / 24000) + 1) / 2)
```

| Tick | Time | Sunlight |
|------|------|----------|
| 0 | Sunrise | 0.63 |
| 6000 | Noon | 1.00 |
| 12000 | Sunset | 0.63 |
| 18000 | Midnight | 0.25 |