### PR TITLE
feat: per-map configurable start camera position (#427)

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/config/MapConfig.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/config/MapConfig.java
@@ -63,6 +63,11 @@ public class MapConfig implements MapSettings {
     private int sorting = 0;
 
     private Vector2i startPos = Vector2i.ZERO;
+    private int startDistance = 1500;
+    private float startRotation = 0;
+    private float startAngle = 0;
+    private float startTilt = 0;
+    private String startView = "perspective";
 
     private String skyColor = "#7dabff";
     private String voidColor = "#000000";

--- a/common/src/main/resources/de/bluecolored/bluemap/config/maps/map.conf
+++ b/common/src/main/resources/de/bluecolored/bluemap/config/maps/map.conf
@@ -28,6 +28,32 @@ sorting: ${sorting}
 # Default is { x: 0, z: 0 }
 start-pos: { x: 0, z: 0 }
 
+# The starting camera distance (zoom level) when the map is opened.
+# You can change this at any time.
+# Default is 1500
+start-distance: 1500
+
+# The starting horizontal rotation of the camera in radians.
+# You can change this at any time.
+# Default is 0
+start-rotation: 0
+
+# The starting vertical angle of the camera in radians (0 = top-down, ~1.2 = low horizon).
+# You can change this at any time.
+# Default is 0
+start-angle: 0
+
+# The starting camera tilt in radians.
+# You can change this at any time.
+# Default is 0
+start-tilt: 0
+
+# The starting view mode for the map. Valid values are: "perspective", "flat", "free".
+# Note: the chosen view must be enabled (see enable-perspective-view, enable-flat-view, enable-free-flight-view).
+# You can change this at any time.
+# Default is "perspective"
+start-view: "perspective"
+
 # The color of the sky as a hex-color.
 # You can change this at any time.
 # Default is "#7dabff"

--- a/common/webapp/src/js/BlueMapApp.js
+++ b/common/webapp/src/js/BlueMapApp.js
@@ -274,25 +274,28 @@ export class BlueMapApp {
 
         if (map) {
             controls.position.set(map.data.startPos.x, 0, map.data.startPos.z);
-            controls.distance = 1500;
-            controls.angle = 0;
-            controls.rotation = 0;
-            controls.tilt = 0;
-            controls.ortho = 0;
         }
 
-        controls.controls = this.mapControls;
-        this.appState.controls.state = "perspective";
-
-        if (this.settings.defaultToFlatView && map.hasView("flat")) {
-            this.setFlatView();
+        // Determine starting view: per-map config first, then global defaultToFlatView, then fallback
+        const startView = map?.data.startView ?? "perspective";
+        if (startView === "flat" && map?.hasView("flat")) {
+            this.setFlatView(0);
+        } else if (startView === "free" && map?.hasView("free")) {
+            this.setFreeFlight(0);
+        } else if (this.settings.defaultToFlatView && map?.hasView("flat")) {
+            this.setFlatView(0);
+        } else if (map && !map.hasView("perspective")) {
+            if (map.hasView("flat")) this.setFlatView(0);
+            else this.setFreeFlight(0);
+        } else {
+            this.setPerspectiveView(0);
         }
 
-        else if (!map.hasView("perspective")) {
-            if (map.hasView("flat"))
-                this.setFlatView();
-            else
-                this.setFreeFlight();
+        if (map) {
+            controls.distance = map.data.startDistance ?? 1500;
+            controls.rotation = map.data.startRotation ?? 0;
+            controls.angle = map.data.startAngle ?? 0;
+            controls.tilt = map.data.startTilt ?? 0;
         }
 
         this.updatePageAddress();

--- a/common/webapp/src/js/map/Map.js
+++ b/common/webapp/src/js/map/Map.js
@@ -65,6 +65,11 @@ export class Map {
 			texturesUrl: mapDataRoot + "/textures.json",
 			name: id,
 			startPos: {x: 0, z: 0},
+			startDistance: 1500,
+			startRotation: 0,
+			startAngle: 0,
+			startTilt: 0,
+			startView: "perspective",
 			skyColor: new Color(),
 			voidColor: new Color(0, 0, 0),
 			ambientLight: 0,
@@ -168,6 +173,12 @@ export class Map {
 				this.data.sorting = Number.isInteger(worldSettings.sorting) ? worldSettings.sorting : this.data.sorting;
 
 				this.data.startPos = {...this.data.startPos, ...vecArrToObj(worldSettings.startPos, true)};
+
+				if (worldSettings.startDistance !== undefined) this.data.startDistance = worldSettings.startDistance;
+				if (worldSettings.startRotation !== undefined) this.data.startRotation = worldSettings.startRotation;
+				if (worldSettings.startAngle !== undefined) this.data.startAngle = worldSettings.startAngle;
+				if (worldSettings.startTilt !== undefined) this.data.startTilt = worldSettings.startTilt;
+				if (worldSettings.startView !== undefined) this.data.startView = worldSettings.startView;
 
 				if (worldSettings.skyColor && worldSettings.skyColor.length >= 3) {
 					this.data.skyColor.setRGB(

--- a/core/src/main/java/de/bluecolored/bluemap/core/map/MapSettings.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/map/MapSettings.java
@@ -34,6 +34,26 @@ public interface MapSettings extends RenderSettings {
 
     Vector2i getStartPos();
 
+    default int getStartDistance() {
+        return 1500;
+    }
+
+    default float getStartRotation() {
+        return 0;
+    }
+
+    default float getStartAngle() {
+        return 0;
+    }
+
+    default float getStartTilt() {
+        return 0;
+    }
+
+    default String getStartView() {
+        return "perspective";
+    }
+
     String getSkyColor();
 
     String getVoidColor();

--- a/core/src/main/java/de/bluecolored/bluemap/core/map/MapSettingsSerializer.java
+++ b/core/src/main/java/de/bluecolored/bluemap/core/map/MapSettingsSerializer.java
@@ -65,8 +65,13 @@ public class MapSettingsSerializer implements JsonSerializer<BmMap> {
         lowres.add("lodCount", context.serialize(lowresTileManager.getLodCount()));
         root.add("lowres", lowres);
 
-        // startPos
+        // startPos and camera defaults
         root.add("startPos", context.serialize(map.getMapSettings().getStartPos()));
+        root.addProperty("startDistance", map.getMapSettings().getStartDistance());
+        root.addProperty("startRotation", map.getMapSettings().getStartRotation());
+        root.addProperty("startAngle", map.getMapSettings().getStartAngle());
+        root.addProperty("startTilt", map.getMapSettings().getStartTilt());
+        root.addProperty("startView", map.getMapSettings().getStartView());
 
         // skyColor
         Color skyColor = new Color().parse(map.getMapSettings().getSkyColor());


### PR DESCRIPTION
## Summary

Closes #427

Extends the map config with five new optional fields that control the full initial camera state when a map is opened without a URL hash:

- **`start-distance`** — zoom/camera distance (default: `1500`)
- **`start-rotation`** — horizontal camera rotation in radians (default: `0`)
- **`start-angle`** — vertical camera angle in radians (default: `0`)
- **`start-tilt`** — camera tilt in radians (default: `0`)
- **`start-view`** — initial view mode: `"perspective"`, `"flat"`, or `"free"` (default: `"perspective"`)

These complement the existing `start-pos` field. All five default to the same values as before, so existing configs are unaffected.

### Example config

```hocon
start-pos: { x: 118, z: -148 }
start-distance: 59
start-rotation: 2.86
start-angle: 1
start-view: "perspective"
```

The values map directly to the URL hash format (`#mapId:x:y:z:distance:rotation:angle:tilt:ortho:state`), making it easy to copy a position from the browser bar into the config.

## Changes

- `MapConfig` — five new fields with safe defaults
- `MapSettings` — default interface getters for the new fields
- `MapSettingsSerializer` — emits all five fields into each map's `settings.json`
- `map.conf` template — documents the new options
- `Map.js` — parses the new fields from `settings.json`
- `BlueMapApp.resetCamera()` — applies per-map start values; `start-view` takes priority over the global `defaultToFlatView` setting, with graceful fallback when the requested view is not enabled on the map

## Test plan

- [x] Open map without URL hash — camera starts at configured position/distance/angle
- [ ] Existing maps with no new config use the same defaults as before (distance 1500, perspective view)
- [ ] `start-view: "flat"` opens in flat/isometric view
- [ ] `start-view: "free"` opens in free-flight view
- [ ] If `start-view` requests a disabled view, falls back to the next available view
- [ ] URL hash still overrides the config start position when present