### PR TITLE
Use undashed UUIDs for skin profile requests

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/plugin/skins/MojangSkinProvider.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/plugin/skins/MojangSkinProvider.java
@@ -56,7 +56,8 @@ public class MojangSkinProvider implements SkinProvider {
     }
 
     private Reader requestProfileJson(UUID playerUUID) throws IOException {
-        URL url = URI.create("https://sessionserver.mojang.com/session/minecraft/profile/" + playerUUID).toURL();
+        String undashedUUID = playerUUID.toString().replace("-", "");
+        URL url = URI.create("https://sessionserver.mojang.com/session/minecraft/profile/" + undashedUUID).toURL();
         return new InputStreamReader(url.openStream());
     }
 


### PR DESCRIPTION
## Summary

Use the undashed UUID form when requesting player profile data from the Mojang session server in `MojangSkinProvider`.

## Why

The session profile endpoint commonly expects UUIDs without hyphens. Using `UUID.toString()` sends the dashed form, which can fail with Yggdrasil-compatible/session-server implementations that only accept the canonical undashed profile id format. In that case BlueMap cannot download the skin and never writes the playerhead asset.

This keeps BlueMap's internal UUID handling and playerhead asset names unchanged; it only normalizes the UUID for the outbound session profile request.

## Testing

- Built the NeoForge release jar from the `v5.7` codebase with Java 21:
  `./gradlew :neoforge:release --no-daemon`
- Deployed the patched NeoForge jar on a NeoForge 1.21.1 server using authlib-injector/LittleSkin.
- Confirmed BlueMap loads successfully after the change.

