### PR TITLE
fix: replace non-breaking space with regular space - in Unicode, it is represented as U+00A0, whereas a standard space bar hit is U+0020

### DIFF
--- a/common/webapp/public/lang/id.conf
+++ b/common/webapp/public/lang/id.conf
@@ -1,175 +1,175 @@
 {
-  pageTitle: "BlueMap - {map}"
-  menu: {
-    title: "Menu"
-    tooltip: "Menu"
-  }
-  map: {
-    unloaded: "Peta tidak tersedia."
-    loading: "Memuat peta..."
-    errored: "Terjadi kesalahan saat memuat peta ini!"
-  }
-  maps: {
-    title: "Peta-Peta"
-    button: "Peta-Peta"
-    tooltip: "Daftar Peta"
-  }
-  markers: {
-    title: "Penanda"
-    button: "Penanda"
-    tooltip: "Daftar Penanda"
-    marker: "penanda | penanda"
-    markerSet: "set-penanda | set-penanda"
-    searchPlaceholder: "Cari..."
-    followPlayerTitle: "Ikuti Pemain"
-    sort {
-      title: "Urutkan berdasarkan"
-      by {
-        default: "bawaan"
-        label: "nama"
-        distance: "jarak"
-      }
-    }
-  }
-  settings: {
-    title: "Pengaturan"
-    button: "Pengaturan"
-  }
-  goFullscreen: {
-    button: "Layar Penuh"
-  }
-  resetCamera: {
-    button: "Atur Ulang Kamera"
-    tooltip: "Atur Ulang Kamera & Posisi"
-  }
-  updateMap: {
-    button: "Perbarui Peta"
-    tooltip: "Bersihkan Tembolok Ubin"
-  }
-  lighting: {
-    title: "Pencahayaan"
-    dayNightSwitch: {
-      tooltip: "Siang/Malam"
-    }
-    sunlight: "Cahaya Matahari"
-    ambientLight: "Cahaya Ambien"
-  }
-  resolution: {
-    title: "Resolusi"
-    high: "Tinggi (SSAA x2)"
-    normal: "Normal (Native x1)"
-    low: "Rendah (Upscaling x0.5)"
-  }
-  mapControls: {
-    title: "Kontrol Peta"
-    showZoomButtons: "Tampilkan Tombol Zum"
-  }
-  freeFlightControls: {
-    title: "Kontrol Free-Flight"
-    mouseSensitivity: "Sensitivitas Tetikus"
-    invertMouseY: "Balikkan Tetikus Y"
-  }
-  renderDistance: {
-    title: "Jarak Render"
-    hiresLayer: "Layer resolusi tinggi"
-    lowersLayer: "Layer resolusi rendah"
-    loadHiresWhileMoving: "Muat resolusi tinggi saat bergerak"
-    off: "Mati"
-  }
-  theme: {
-    title: "Tema"
-    default: "Bawaan (Sistem/Peramban)"
-    dark: "Gelap"
-    light: "Terang"
+  pageTitle: "BlueMap - {map}"
+  menu: {
+    title: "Menu"
+    tooltip: "Menu"
+  }
+  map: {
+    unloaded: "Peta tidak tersedia."
+    loading: "Memuat peta..."
+    errored: "Terjadi kesalahan saat memuat peta ini!"
+  }
+  maps: {
+    title: "Peta-Peta"
+    button: "Peta-Peta"
+    tooltip: "Daftar Peta"
+  }
+  markers: {
+    title: "Penanda"
+    button: "Penanda"
+    tooltip: "Daftar Penanda"
+    marker: "penanda | penanda"
+    markerSet: "set-penanda | set-penanda"
+    searchPlaceholder: "Cari..."
+    followPlayerTitle: "Ikuti Pemain"
+    sort {
+      title: "Urutkan berdasarkan"
+      by {
+        default: "bawaan"
+        label: "nama"
+        distance: "jarak"
+      }
+    }
+  }
+  settings: {
+    title: "Pengaturan"
+    button: "Pengaturan"
+  }
+  goFullscreen: {
+    button: "Layar Penuh"
+  }
+  resetCamera: {
+    button: "Atur Ulang Kamera"
+    tooltip: "Atur Ulang Kamera & Posisi"
+  }
+  updateMap: {
+    button: "Perbarui Peta"
+    tooltip: "Bersihkan Tembolok Ubin"
+  }
+  lighting: {
+    title: "Pencahayaan"
+    dayNightSwitch: {
+      tooltip: "Siang/Malam"
+    }
+    sunlight: "Cahaya Matahari"
+    ambientLight: "Cahaya Ambien"
+  }
+  resolution: {
+    title: "Resolusi"
+    high: "Tinggi (SSAA x2)"
+    normal: "Normal (Native x1)"
+    low: "Rendah (Upscaling x0.5)"
+  }
+  mapControls: {
+    title: "Kontrol Peta"
+    showZoomButtons: "Tampilkan Tombol Zum"
+  }
+  freeFlightControls: {
+    title: "Kontrol Free-Flight"
+    mouseSensitivity: "Sensitivitas Tetikus"
+    invertMouseY: "Balikkan Tetikus Y"
+  }
+  renderDistance: {
+    title: "Jarak Render"
+    hiresLayer: "Layer resolusi tinggi"
+    lowersLayer: "Layer resolusi rendah"
+    loadHiresWhileMoving: "Muat resolusi tinggi saat bergerak"
+    off: "Mati"
+  }
+  theme: {
+    title: "Tema"
+    default: "Bawaan (Sistem/Peramban)"
+    dark: "Gelap"
+    light: "Terang"
     contrast: "Kontras"
-  }
-  chunkBorders: {
-    button: "Tampilkan batas bongkahan"
-  }
-  debug: {
-    button: "Awakutu"
-  }
-  resetAllSettings: {
-    button: "Reset Semua Pengaturan"
-  }
-  players: {
-    title: "Pemain"
-    tooltip: "Daftar Pemain"
-  }
-  compass: {
-    tooltip: "Kompas / Hadap Utara"
-  }
-  screenshot: {
-    title: "Screenshot"
-    button: "Ambil Tangkapan Layar"
-    clipboard: "Salin ke Papan Klip"
-  }
-  controls: {
-    title: "Tampilan / Kontrol"
-    perspective: {
-      button: "Perspektif"
-      tooltip: "Tampilan Perspektif"
-    }
-    flatView: {
-      button: "Datar"
-      tooltip: "Tampilan Ortografik / Datar"
-    }
-    freeFlight: {
-      button: "Free-Flight"
-      tooltip: "Mode Free-Flight / Spektator"
-    }
-  }
-  language: {
-    title: "Bahasa"
-  }
-  blockTooltip: {
-    block: "Blok"
-    position: "Posisi"
-    chunk: "Bongkahan"
-    region: {
-      region: "Wilayah"
-      file: "Berkas"
-    }
-    light: {
-      light: "Cahaya"
-      sun: "Matahari"
-      block: "Blok"
-    }
-    clipboard: "klik untuk menyalin"
-  }
-  info: {
-    title: "Info"
-    button: "Info"
-    content: """
+  }
+  chunkBorders: {
+    button: "Tampilkan batas bongkahan"
+  }
+  debug: {
+    button: "Awakutu"
+  }
+  resetAllSettings: {
+    button: "Reset Semua Pengaturan"
+  }
+  players: {
+    title: "Pemain"
+    tooltip: "Daftar Pemain"
+  }
+  compass: {
+    tooltip: "Kompas / Hadap Utara"
+  }
+  screenshot: {
+    title: "Screenshot"
+    button: "Ambil Tangkapan Layar"
+    clipboard: "Salin ke Papan Klip"
+  }
+  controls: {
+    title: "Tampilan / Kontrol"
+    perspective: {
+      button: "Perspektif"
+      tooltip: "Tampilan Perspektif"
+    }
+    flatView: {
+      button: "Datar"
+      tooltip: "Tampilan Ortografik / Datar"
+    }
+    freeFlight: {
+      button: "Free-Flight"
+      tooltip: "Mode Free-Flight / Spektator"
+    }
+  }
+  language: {
+    title: "Bahasa"
+  }
+  blockTooltip: {
+    block: "Blok"
+    position: "Posisi"
+    chunk: "Bongkahan"
+    region: {
+      region: "Wilayah"
+      file: "Berkas"
+    }
+    light: {
+      light: "Cahaya"
+      sun: "Matahari"
+      block: "Blok"
+    }
+    clipboard: "klik untuk menyalin"
+  }
+  info: {
+    title: "Info"
+    button: "Info"
+    content: """
 <img src="assets/logo.png" style="display: block; width: 40%; margin: 3em auto; border-radius: 50%">
 <p>
-    <h2>Kontrol Tetikus:</h2>
-    <table>
-        <tr><th>gerak</th><td><kbd>klik kiri</kbd> + seret</td></tr>
-        <tr><th>zoom</th><td><kbd>roda tetikus</kbd> (gulir)</td></tr>
-        <tr><th>putar / miringkan</th><td><kbd>klik kanan</kbd> + seret</td></tr>
-    </table>
+    <h2>Kontrol Tetikus:</h2>
+    <table>
+        <tr><th>gerak</th><td><kbd>klik kiri</kbd> + seret</td></tr>
+        <tr><th>zoom</th><td><kbd>roda tetikus</kbd> (gulir)</td></tr>
+        <tr><th>putar / miringkan</th><td><kbd>klik kanan</kbd> + seret</td></tr>
+    </table>
 </p>
 <p>
-    <h2>Kontrol Keyboard:</h2>
-    <table>
-        <tr><th>gerak</th><td><kbd>wasd</kbd> / <kbd>tombol panah</kbd></td></tr>
-        <tr><th>zoom</th><td>Numpad: <kbd>+</kbd>/<kbd>-</kbd> atau <kbd>Ins</kbd>/<kbd>Home</kbd></td></tr>
-        <tr><th>putar / miringkan</th><td><kbd>Left-Alt</kbd> + <kbd>wasd</kbd> / <kbd>tombol panah</kbd> atau <kbd>Delete</kbd>/<kbd>End</kbd>/<kbd>Page Up</kbd>/<kbd>Page Down</kbd></td></tr>
-    </table>
+    <h2>Kontrol Keyboard:</h2>
+    <table>
+        <tr><th>gerak</th><td><kbd>wasd</kbd> / <kbd>tombol panah</kbd></td></tr>
+        <tr><th>zoom</th><td>Numpad: <kbd>+</kbd>/<kbd>-</kbd> atau <kbd>Ins</kbd>/<kbd>Home</kbd></td></tr>
+        <tr><th>putar / miringkan</th><td><kbd>Left-Alt</kbd> + <kbd>wasd</kbd> / <kbd>tombol panah</kbd> atau <kbd>Delete</kbd>/<kbd>End</kbd>/<kbd>Page Up</kbd>/<kbd>Page Down</kbd></td></tr>
+    </table>
 </p>
 <p>
-    <h2>Kontrol Sentuh:</h2>
-    <table>
-        <tr><th>gerak</th><td>sentuh + seret</td></tr>
-        <tr><th>zoom</th><td>sentuh dengan dua jari + cubit</td></tr>
-        <tr><th>putar / miringkan</th><td>sentuh dengan dua jari + putar / gerakkan ke atas/bawah</td></tr>
-    </table>
+    <h2>Kontrol Sentuh:</h2>
+    <table>
+        <tr><th>gerak</th><td>sentuh + seret</td></tr>
+        <tr><th>zoom</th><td>sentuh dengan dua jari + cubit</td></tr>
+        <tr><th>putar / miringkan</th><td>sentuh dengan dua jari + putar / gerakkan ke atas/bawah</td></tr>
+    </table>
 </p>
 <br><hr>
 <p class="info-footer">
-    Peta ini dibuat dengan &#9829; menggunakan <a href="https://bluecolo.red/bluemap">BlueMap</a> {version}
+    Peta ini dibuat dengan &#9829; menggunakan <a href="https://bluecolo.red/bluemap">BlueMap</a> {version}
 </p>
 """
-  }
+  }
 }

--- a/common/webapp/public/lang/pl.conf
+++ b/common/webapp/public/lang/pl.conf
@@ -50,7 +50,7 @@
   freeFlightControls: {
     title: "Sterowanie w locie swobodnym"
     mouseSensitivity: "Czułość myszy"
-    invertMouseY: "Odwróć oś pionową myszy"
+    invertMouseY: "Odwróć oś pionową myszy"
   }
   renderDistance: {
     title: "Odległość renderowania"
@@ -75,7 +75,7 @@
     tooltip: "Lista graczy"
   }
   compass: {
-    tooltip: "Kompas / zwroć na północ"
+    tooltip: "Kompas / zwroć na północ"
   }
   screenshot: {
     title: "Zrzut ekranu"
@@ -171,7 +171,7 @@
 </p>
 <br><hr>
 <p class="info-footer">
-Ta mapa została wygenerowana z &#9829; za pomocą <a href="https://bluecolo.red/bluemap">BlueMap</a> {version}</p>
+Ta mapa została wygenerowana z &#9829; za pomocą <a href="https://bluecolo.red/bluemap">BlueMap</a> {version}</p>
 """
   }
 }

--- a/common/webapp/public/lang/zh-CN.conf
+++ b/common/webapp/public/lang/zh-CN.conf
@@ -84,7 +84,7 @@
     contrast: "高对比模式"
   }
   chunkBorders: {
-    button: "显示区块边界"  
+    button: "显示区块边界"  
   }
   debug: {
     button: "调试"


### PR DESCRIPTION
The character I replaced is a Non-Breaking Space (often abbreviated as NBSP).
In Unicode, it is represented as U+00A0, whereas a standard space bar hit is U+0020.
To the naked eye, it looks exactly like a regular space, but it behaves very differently under the hood.

A standard space tells a browser or word processor, "You can break the line here if you run out of room." A Non-Breaking Space does the exact opposite. It creates a space between two words but forces them to stay glued together on the same line, preventing an awkward line break (word wrap).

It is redundant and is problematic to work with thus I've replace it repo-wide with a regular space.

---

I've found it by browsing lang files as VS Code highlighted it in distinct way (look at the "yellow orange-ish" in the line 53):

<img width="2520" height="1117" alt="image" src="https://github.com/user-attachments/assets/b0070ca5-54ea-4ca8-8ea4-daa0fc4d4617" />
