### PR TITLE
Make it possible to host BlueMap on static web hosts with client decompression mode

### DIFF
--- a/common/webapp/src/js/BlueMapApp.js
+++ b/common/webapp/src/js/BlueMapApp.js
@@ -76,6 +76,7 @@ export class BlueMapApp {
          *      maps: string[],
          *      scripts: string[],
          *      styles: string[]
+         *      clientDecompression: boolean,
          *  }}
          **/
         this.settings = null;
@@ -308,7 +309,7 @@ export class BlueMapApp {
         // create maps
         if (settings.maps !== undefined){
             let loadingPromises = settings.maps.map(mapId => {
-                let map = new BlueMapMap(mapId, settings.mapDataRoot + "/" + mapId, settings.liveDataRoot + "/" + mapId, this.loadBlocker, this.mapViewer.events);
+                let map = new BlueMapMap(mapId, settings.mapDataRoot + "/" + mapId, settings.liveDataRoot + "/" + mapId, this.loadBlocker, this.mapViewer.events, this.settings.clientDecompression);
                 maps.push(map);
 
                 return map.loadSettings(this.mapViewer.revalidatedUrls)
@@ -355,6 +356,7 @@ export class BlueMapApp {
                 ],
                 scripts: [],
                 styles: [],
+                clientDecompression: false,
                 ...loaded
             };
         }

--- a/common/webapp/src/js/map/Map.js
+++ b/common/webapp/src/js/map/Map.js
@@ -49,8 +49,9 @@ export class Map {
 	 * @param liveDataRoot {string}
 	 * @param loadBlocker {function: Promise<void>}
 	 * @param events {EventTarget}
+	 * @param clientDecompression {boolean}
 	 */
-	constructor(id, mapDataRoot, liveDataRoot, loadBlocker, events = null) {
+	constructor(id, mapDataRoot, liveDataRoot, loadBlocker, events = null, clientDecompression) {
 		Object.defineProperty( this, 'isMap', { value: true } );
 
 		this.loadBlocker = loadBlocker;
@@ -62,7 +63,7 @@ export class Map {
 			mapDataRoot: mapDataRoot,
 			liveDataRoot: liveDataRoot,
 			settingsUrl: mapDataRoot + "/settings.json",
-			texturesUrl: mapDataRoot + "/textures.json",
+			texturesUrl: mapDataRoot + (clientDecompression ? "/textures.json.gz" : "/textures.json"),
 			name: id,
 			startPos: {x: 0, z: 0},
 			skyColor: new Color(),
@@ -133,7 +134,8 @@ export class Map {
 									this.hiresMaterial,
 									this.data.hires,
 									this.loadBlocker,
-									revalidatedUrls
+									revalidatedUrls,
+									this.data.clientDecompression
 								), this.onTileLoad("hires"), this.onTileUnload("hires"), this.events);
 								this.hiresTileManager.scene.matrixWorldAutoUpdate = false;
 
@@ -285,6 +287,7 @@ export class Map {
 			let loader = new RevalidatingFileLoader();
 			loader.setRevalidatedUrls(revalidatedUrls);
 			loader.setResponseType("json");
+			loader.setClientDecompression(this.data.clientDecompression);
 			loader.load(this.data.texturesUrl,
 				resolve,
 				() => {},

--- a/common/webapp/src/js/map/Map.js
+++ b/common/webapp/src/js/map/Map.js
@@ -83,7 +83,8 @@ export class Map {
 			perspectiveView: false,
 			flatView: false,
 			freeFlightView: false,
-			views: ["perspective", "flat", "free"]
+			views: ["perspective", "flat", "free"],
+			clientDecompression: clientDecompression
 		});
 
 		this.raycaster = new Raycaster();

--- a/common/webapp/src/js/map/Map.js
+++ b/common/webapp/src/js/map/Map.js
@@ -129,28 +129,28 @@ export class Map {
                 this.hiresMaterial = this.createHiresMaterial(hiresVertexShader, hiresFragmentShader, uniforms, textures);
 
                 this.hiresTileManager = new TileManager(new TileLoader(
-					`${this.data.mapDataRoot}/tiles/0/`,
-					this.hiresMaterial,
-					this.data.hires,
-					this.loadBlocker,
-					revalidatedUrls
-				), this.onTileLoad("hires"), this.onTileUnload("hires"), this.events);
-				this.hiresTileManager.scene.matrixWorldAutoUpdate = false;
+									`${this.data.mapDataRoot}/tiles/0/`,
+									this.hiresMaterial,
+									this.data.hires,
+									this.loadBlocker,
+									revalidatedUrls
+								), this.onTileLoad("hires"), this.onTileUnload("hires"), this.events);
+								this.hiresTileManager.scene.matrixWorldAutoUpdate = false;
 
-                this.lowresTileManager = [];
-				for (let i = 0; i < this.data.lowres.lodCount; i++) {
-					this.lowresTileManager[i] = new TileManager(new LowresTileLoader(
-						`${this.data.mapDataRoot}/tiles/`,
-						this.data.lowres,
-						i + 1,
-						lowresVertexShader,
-						lowresFragmentShader,
-						uniforms,
-						async () => {},
-						revalidatedUrls
-					), this.onTileLoad("lowres"), this.onTileUnload("lowres"), this.events);
-					this.lowresTileManager[i].scene.matrixWorldAutoUpdate = false;
-				}
+								this.lowresTileManager = [];
+								for (let i = 0; i < this.data.lowres.lodCount; i++) {
+									this.lowresTileManager[i] = new TileManager(new LowresTileLoader(
+										`${this.data.mapDataRoot}/tiles/`,
+										this.data.lowres,
+										i + 1,
+										lowresVertexShader,
+										lowresFragmentShader,
+										uniforms,
+										async () => {},
+										revalidatedUrls
+									), this.onTileLoad("lowres"), this.onTileUnload("lowres"), this.events);
+									this.lowresTileManager[i].scene.matrixWorldAutoUpdate = false;
+								}
 
                 alert(this.events, `Map '${this.data.id}' is loaded.`, "fine");
             });

--- a/common/webapp/src/js/map/TileLoader.js
+++ b/common/webapp/src/js/map/TileLoader.js
@@ -39,8 +39,9 @@ export class TileLoader {
      * }}
      * @param loadBlocker {function: Promise}
      * @param revalidatedUrls {Set<string> | undefined}
+     * @param clientDecompression {boolean}
      */
-    constructor(tilePath, material, tileSettings, loadBlocker = () => Promise.resolve(), revalidatedUrls) {
+    constructor(tilePath, material, tileSettings, loadBlocker = () => Promise.resolve(), revalidatedUrls, clientDecompression) {
         Object.defineProperty( this, 'isTileLoader', { value: true } );
 
         this.tilePath = tilePath;
@@ -54,12 +55,17 @@ export class TileLoader {
         this.fileLoader = new RevalidatingFileLoader();
         this.fileLoader.setResponseType('arraybuffer');
         this.fileLoader.setRevalidatedUrls(this.revalidatedUrls);
+        this.fileLoader.setClientDecompression(clientDecompression);
+        this.clientDecompression = clientDecompression;
 
         this.bufferGeometryLoader = new PRBMLoader();
     }
 
     load = (tileX, tileZ, cancelCheck = () => false) => {
         let tileUrl = this.tilePath + pathFromCoords(tileX, tileZ) + '.prbm';
+        if (this.clientDecompression) {
+            tileUrl += '.gz';
+        }
 
         return new Promise((resolve, reject) => {
             this.fileLoader.setRevalidatedUrls(this.revalidatedUrls);

--- a/common/webapp/src/js/util/RevalidatingFileLoader.js
+++ b/common/webapp/src/js/util/RevalidatingFileLoader.js
@@ -56,6 +56,14 @@ export class RevalidatingFileLoader extends Loader {
         this.responseType = "";
 
         /**
+         * Whether client-side decompression is required.
+         * 
+         * @type {boolean}
+         * @default false;
+         */
+        this.clientDecompression = false;
+
+        /**
          * Used for aborting requests.
          *
          * @private
@@ -246,6 +254,15 @@ export class RevalidatingFileLoader extends Loader {
                     );
                 }
             })
+            .then(async (response) => {
+                if (this.clientDecompression) {
+                    const ds = new DecompressionStream("gzip");
+                    const decompressedStream = (await response.blob()).stream().pipeThrough(ds);
+                    const decompressedResponse = new Response(decompressedStream);
+                    return decompressedResponse;
+                }
+                return response;
+            })
             .then((response) => {
                 switch (responseType) {
                     case "arraybuffer":
@@ -341,6 +358,16 @@ export class RevalidatingFileLoader extends Loader {
      */
     setMimeType(value) {
         this.mimeType = value;
+        return this;
+    }
+
+    /**
+     * Sets whether client-side decompression is required.
+     * @param {boolean} value - True if the client must decompress the loaded file
+     * @returns {FileLoader} A reference to this file loader.
+     */
+    setClientDecompression(value) {
+        this.clientDecompression = value;
         return this;
     }
 


### PR DESCRIPTION
## What it does
This PR is intended to address #293 by allowing you to host the `web` directory generated by BlueMap on a static web host, such as Github Pages. This is achieved by modifying `web/settings.json` and adding `"clientDecompression": true`.

A Github Pages demo is currently available from the following links (though I may move it soon):
- Demo: https://fredchan.org/shack-village-maps
- GH repo: https://github.com/fechan/shack-village-maps


## Implementation details
There are two places that request files that are stored gzipped at rest: `textures.json` and PRBMs. When `clientDecompression` is on, it will attempt to fetch `<filename>.gz` instead of the normal filename, using `RevalidatingFileLoader`. After setting`RevalidatingFileLoader.setClientDecompression(true)`, the file loader will decompress the gzipped data using the browser-native [Compression Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API).

## Possible issues
* Client decompression will not work in the Vite preview environment (i.e. when you use `npm run dev`), since the decompression code errors out with `Failed to read data from the ReadableStream: “TypeError: The input data is corrupted: incorrect header check”`. This seems to be the same issue faced by these folks: https://github.com/monochrome-music/monochrome/issues/320. However, this does not affect the production environment.