### PR TITLE
Add security headers

### DIFF
--- a/common/src/main/java/de/bluecolored/bluemap/common/plugin/Plugin.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/plugin/Plugin.java
@@ -241,7 +241,7 @@ public class Plugin implements ServerEventListener {
                         webRequestHandler.register(
                                 "maps/" + Pattern.quote(id) + "/(.*)",
                                 "$1",
-                                new BlueMapResponseModifier(mapRequestHandler)
+                                mapRequestHandler
                         );
                     }
 
@@ -260,7 +260,7 @@ public class Plugin implements ServerEventListener {
                         webServer = new HttpServer(
                                 "BlueMap-Webserver",
                                 new LoggingRequestHandler(
-                                        webRequestHandler,
+                                        new BlueMapResponseModifier(webRequestHandler),
                                         webserverConfig.getLog().getFormat(),
                                         webLogger
                                 )

--- a/common/src/main/java/de/bluecolored/bluemap/common/web/BlueMapResponseModifier.java
+++ b/common/src/main/java/de/bluecolored/bluemap/common/web/BlueMapResponseModifier.java
@@ -28,7 +28,6 @@ import de.bluecolored.bluemap.common.web.http.HttpRequest;
 import de.bluecolored.bluemap.common.web.http.HttpRequestHandler;
 import de.bluecolored.bluemap.common.web.http.HttpResponse;
 import de.bluecolored.bluemap.common.web.http.HttpStatusCode;
-import de.bluecolored.bluemap.core.BlueMap;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -41,7 +40,6 @@ public class BlueMapResponseModifier implements HttpRequestHandler {
 
     public BlueMapResponseModifier(HttpRequestHandler delegate) {
         this.delegate = delegate;
-        this.serverName = "BlueMap/" + BlueMap.VERSION;
     }
 
     @Override
@@ -53,7 +51,12 @@ public class BlueMapResponseModifier implements HttpRequestHandler {
             response.setBody(status.getCode() + " - " + status.getMessage() + "\n" + this.serverName);
         }
 
-        response.addHeader("Server", this.serverName);
+        response.addHeader("Server", "BlueMap");
+        response.addHeader("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; object-src 'none';");
+        response.addHeader("X-Frame-Options", "SAMEORIGIN");
+        response.addHeader("X-Content-Type-Options", "nosniff");
+        response.addHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+        response.addHeader("Permissions-Policy", "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(self), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(self), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()");
 
         return response;
     }


### PR DESCRIPTION
This pull request adds several security headers to the HTTP responses.

| **Before** | **Now** |
|--------|--------|
| <img width="1800" height="1504" alt="grafik" src="https://github.com/user-attachments/assets/0a4d15df-e7db-46ba-a2b2-ee46b0d279fd" /> | <img width="1800" height="1231" alt="grafik" src="https://github.com/user-attachments/assets/303ab93a-f91f-4b70-96fb-fdc432b0125a" /> |
| [Result](https://securityheaders.com/?q=https%3A%2F%2Fbluecolored.de%2Fbluemap%2F&hide=on&followRedirects=on) | [Result](https://securityheaders.com/?q=https%3A%2F%2Fminecraft.woody.pizza&hide=on&followRedirects=on) |
| [BlueMap](https://bluecolored.de/bluemap/) | [BlueMap](https://minecraft.woody.pizza) | 

_https://bluecolored.de/bluemap/ uses nginx, but the result would be the same on the BlueMap web server._

**Security improvements:**

This adds several HTTP security headers to all responses, including `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy`.

I didn't include `Strict-Transport-Security` because BlueMap's web server doesn't handle HTTPS. If you use a reverse proxy (like Nginx, Caddy, or Cloudflare) for HTTPS, set this header there.

I also changed the `Server` HTTP header from a versioned string (e.g., `BlueMap/1.0`) to simply `BlueMap`.

**What does not work anymore:**
If users load their own scripts or CSS cross-origin, this is now blocked by CSP. If we should change this just let me know.